### PR TITLE
chore: disable ipv6 in network configuration

### DIFF
--- a/system/nixos/core/network.nix
+++ b/system/nixos/core/network.nix
@@ -11,4 +11,6 @@ in
   networking.wireless.iwd = lib.mkIf (backend == "iwd") {
     enable = true;
   };
+
+  networking.enableIPv6 = false;
 }


### PR DESCRIPTION
## Summary
- Disables IPv6 system-wide in `system/nixos/core/network.nix`.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#desktop` activates cleanly.
- [ ] `ip -6 addr` no longer shows global addresses on the primary interface.