### PR TITLE
feat: add hyprwhspr-rs voice dictation

### DIFF
--- a/profile/common/configuration.nix
+++ b/profile/common/configuration.nix
@@ -72,6 +72,7 @@ in
     # ../../system/nixos/mounts/cloud-storages.nix
 
     ../../system/nixos/utils/applications.nix
+    ../../system/nixos/utils/hyprwhspr.nix
     ../../system/nixos/utils/docker.nix
     ../../system/utils/downloading.nix
     ../../system/nixos/utils/podman.nix

--- a/profile/desktop/options.nix
+++ b/profile/desktop/options.nix
@@ -7,6 +7,7 @@
     desktop = {
       dconf.enable = true;
       hyprland.enable = true;
+      hyprwhspr.enable = true;
       xdg.enable = true;
       kdeconnect.enable = true;
     };

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -229,12 +229,12 @@ in
         "$mod, mouse_down, workspace, e+1"
         "$mod, mouse_up, workspace, e-1"
 
-        # hyprwhspr-rs: hold ALT+N to dictate
-        "ALT, N, exec, hyprwhspr-rs record start"
+        # hyprwhspr-rs: hold ALT+V to dictate
+        "ALT, V, exec, hyprwhspr-rs record start"
       ];
 
       bindr = [
-        "ALT, N, exec, hyprwhspr-rs record stop"
+        "ALT, V, exec, hyprwhspr-rs record stop"
       ];
 
       bindm = [

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -228,6 +228,13 @@ in
         # Scroll through existing workspaces with mod + scroll
         "$mod, mouse_down, workspace, e+1"
         "$mod, mouse_up, workspace, e-1"
+
+        # hyprwhspr-rs: hold ALT+N to dictate
+        "ALT, N, exec, hyprwhspr-rs record start"
+      ];
+
+      bindr = [
+        "ALT, N, exec, hyprwhspr-rs record stop"
       ];
 
       bindm = [

--- a/system/nixos/utils/hyprwhspr.nix
+++ b/system/nixos/utils/hyprwhspr.nix
@@ -1,0 +1,26 @@
+{
+  inputs,
+  pkgs-unstable,
+  config,
+  lib,
+  ...
+}:
+let
+  username = config.settings.username;
+in
+{
+  imports = [
+    "${inputs.nixpkgs-unstable}/nixos/modules/services/misc/hyprwhspr-rs.nix"
+  ];
+
+  config = lib.mkIf config.features.desktop.hyprwhspr.enable {
+    services.hyprwhspr-rs = {
+      enable = true;
+      package = pkgs-unstable.hyprwhspr-rs;
+    };
+
+    environment.systemPackages = [ pkgs-unstable.hyprwhspr-rs ];
+
+    users.users.${username}.extraGroups = [ "input" ];
+  };
+}

--- a/system/options.nix
+++ b/system/options.nix
@@ -100,6 +100,10 @@ with lib;
         enable = mkEnableOption "Hyprland window manager";
       };
 
+      hyprwhspr = {
+        enable = mkEnableOption "hyprwhspr-rs speech-to-text dictation";
+      };
+
       xdg = {
         enable = mkEnableOption "XDG desktop portals";
       };


### PR DESCRIPTION
## Summary
- New `features.desktop.hyprwhspr` enable flag (on for desktop).
- New `system/nixos/utils/hyprwhspr.nix` imports the unstable NixOS module + package (`pkgs-unstable.hyprwhspr-rs`, 0.3.27 — not yet in 25.11), adds the user to `input`, and exposes the binary on system PATH so Hyprland's `exec` dispatcher can find it.
- Hyprland binds: ALT+N hold-to-talk (`bind` start on press, `bindr` stop on release) over IPC.

Stacked on #8 (microvm) due to overlap in `system/options.nix`, `profile/common/configuration.nix`, and `profile/desktop/options.nix`. Rebase target switches to `main` after #8 merges.

## Notes
- First run requires a whisper model at `~/.local/share/hyprwhspr-rs/models/ggml-base.bin`. Upstream tool has no auto-fetch; download from huggingface once.
- Default config (`~/.config/hyprwhspr-rs/config.jsonc`) ships an internal `shortcuts.press` that tries to grab `/dev/input/event*` directly and warns "No keyboard devices found" — harmless since Hyprland drives capture over the IPC socket. Remove the `shortcuts` block from the user config to silence it.

## Test plan
- [x] `nixos-rebuild switch` succeeds.
- [x] `systemctl --user status hyprwhspr-rs` is active after model is present.
- [x] Hold ALT+N → daemon log shows record start/stop + transcription pipeline, text injected into focused field.