### PR TITLE
feat(dev-vm): persist ssh host keys + add dev alias

### DIFF
--- a/profile/dev-vm/configuration.nix
+++ b/profile/dev-vm/configuration.nix
@@ -23,11 +23,24 @@
     password = "s1n7ax";
     createHome = true;
     home = "/home/${config.settings.username}";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICCbb/a4qlKElECtcA07ImQk+QfOILQ5IkiXjpCRqhlL srineshnisala@gmail.com"
+    ];
   };
 
   systemd.tmpfiles.rules = [
     "d /home/${config.settings.username} 0700 ${config.settings.username} ${config.settings.username} -"
   ];
 
-  services.openssh.settings.PasswordAuthentication = true;
+  services.openssh = {
+    settings.PasswordAuthentication = true;
+    hostKeys = [
+      {
+        path = "/persist/ssh-host-keys/ssh_host_ed25519_key";
+        type = "ed25519";
+      }
+    ];
+  };
+
+  systemd.services.sshd.unitConfig.RequiresMountsFor = "/persist/ssh-host-keys";
 }

--- a/system/home-manager/profile/desktop/ssh.nix
+++ b/system/home-manager/profile/desktop/ssh.nix
@@ -15,6 +15,13 @@
         hostname = "64.225.84.64";
         identityFile = "~/.ssh/digitalocean";
       };
+
+      "dev" = {
+        user = "s1n7ax";
+        hostname = "localhost";
+        port = 2222;
+        identityFile = "~/.ssh/id_ed25519";
+      };
     };
   };
 }

--- a/system/nixos/utils/microvm.nix
+++ b/system/nixos/utils/microvm.nix
@@ -59,6 +59,13 @@ with lib;
                 fsType = "ext4";
                 autoCreate = true;
               }
+              {
+                mountPoint = "/persist/ssh-host-keys";
+                image = "/var/lib/microvms/dev-vm/ssh-host-keys.img";
+                size = 64;
+                fsType = "ext4";
+                autoCreate = true;
+              }
             ];
 
             shares = [


### PR DESCRIPTION
## Summary
- Mount `/persist/ssh-host-keys` as a dedicated ext4 volume so the dev-vm's `ssh_host_ed25519_key` survives rebuilds and restarts (no more host-key mismatch warnings).
- Authorize the host's `id_ed25519.pub` in the VM so `ssh dev-vm` works key-based out of the box.
- Add `dev` ssh alias in home-manager (localhost:2222 -> dev-vm).

## Test plan
- [x] `sudo nixos-rebuild switch --flake .#nixos` succeeds
- [x] `sudo systemctl restart microvm@dev-vm` brings VM up
- [x] `ssh-keyscan -p 2222 -t ed25519 localhost` returns a stable key across VM restarts
- [ ] `ssh dev` logs in as `s1n7ax` using `id_ed25519`