### PR TITLE
feat(hyprland): migrate to Lua config + unstable package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+system/home-manager/applications/hyprland/.luarc.json

--- a/flake.lock
+++ b/flake.lock
@@ -57,6 +57,27 @@
         "type": "github"
       }
     },
+    "home-manager-master": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "microvm": {
       "inputs": {
         "nixpkgs": [
@@ -181,6 +202,7 @@
       "inputs": {
         "hardware": "hardware",
         "home-manager": "home-manager",
+        "home-manager-master": "home-manager-master",
         "microvm": "microvm",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nixpkgs": "nixpkgs_2",

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,10 @@
       url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    home-manager-master = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/profile/desktop/options.nix
+++ b/profile/desktop/options.nix
@@ -1,6 +1,8 @@
+{ pkgs-unstable, lib, ... }:
 {
   settings = {
     network.backend = "networkmanager";
+    wm.package = lib.mkForce pkgs-unstable.hyprland;
   };
 
   features = {

--- a/system/home-manager/applications/alias.nix
+++ b/system/home-manager/applications/alias.nix
@@ -93,7 +93,7 @@ let
 
     # nixos
     nixos = "cd ~/Workspace/nixos && sudo nix flake update && sudo nixos-rebuild switch --upgrade --flake ./#desktop";
-    nixos-clean = "nix-collect-garbage -d && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot";
+    nixos-clean = "nix-collect-garbage -d && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot && sudo nix-store --optimise";
   };
 in
 {

--- a/system/home-manager/applications/alias.nix
+++ b/system/home-manager/applications/alias.nix
@@ -24,7 +24,7 @@ let
     lg = "lazygit";
     ld = "lazydocker";
     yt = "yt-dlp";
-    h = "Hyprland";
+    h = "start-hyprland";
     rm = "trash";
     p = "pnpm";
     px = "pnpm dlx";

--- a/system/home-manager/applications/ghostty.nix
+++ b/system/home-manager/applications/ghostty.nix
@@ -5,7 +5,7 @@
     enableFishIntegration = true;
 
     settings = {
-      theme = "catppuccin-mocha";
+      theme = "Catppuccin Mocha";
       font-family = config.settings.font.name;
       font-size = config.settings.font.size;
       cursor-style = "block";

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -120,7 +120,7 @@ in
           leaf = "workspaces";
           enabled = true;
           speed = 1;
-          curve = "default";
+          bezier = "default";
         }
         {
           leaf = "windows";

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -1,9 +1,20 @@
-{ config, ... }:
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
 let
   cursor_name = config.settings.cursor.name;
-  cursor_size = builtins.toString config.settings.cursor.size;
+  cursor_size = config.settings.cursor.size;
 in
 {
+  disabledModules = [ "services/window-managers/hyprland.nix" ];
+
+  imports = [
+    "${inputs.home-manager-master}/modules/services/window-managers/hyprland.nix"
+  ];
+
   services.hyprpaper = {
     enable = true;
     settings = {
@@ -19,241 +30,120 @@ in
 
   wayland.windowManager.hyprland = {
     enable = true;
-    # package = config.settings.wm.package;
-
+    package = config.settings.wm.package;
+    configType = "lua";
     xwayland.enable = true;
 
     settings = {
-      xwayland = {
-        force_zero_scaling = true;
+      config = {
+        xwayland = {
+          force_zero_scaling = true;
+        };
+
+        input = {
+          kb_layout = "us";
+          repeat_delay = 190;
+          repeat_rate = 200;
+          follow_mouse = 1;
+          touchpad = {
+            natural_scroll = false;
+          };
+          sensitivity = -0.6;
+          accel_profile = "flat";
+          scroll_points = "1 1";
+        };
+
+        general = {
+          gaps_in = 5;
+          gaps_out = 10;
+          border_size = 5;
+          "col.active_border" = {
+            colors = [
+              "rgba(8a1671ff)"
+              "rgba(8a132fff)"
+            ];
+            angle = 45;
+          };
+          "col.inactive_border" = "rgba(1c1b1c01)";
+          layout = "master";
+        };
+
+        decoration = {
+          shadow = {
+            enabled = false;
+            range = 4;
+          };
+          rounding = 10;
+          blur = {
+            enabled = false;
+            size = 5;
+            passes = 3;
+            vibrancy = 0.5;
+          };
+        };
+
+        master = {
+          new_status = "slave";
+        };
       };
-
-      windowrulev2 = [
-        "workspace 1, class:(org.kde.digikam)"
-        "workspace 2, class:(steam), floating:[0]"
-        "workspace 2, title:(Steam), floading:[0]"
-        "workspace 3, class:(Tor Browser)"
-        "workspace 3, class:(obsidian)"
-
-        "workspace 4, class:(firefox)"
-        "workspace 4, class:(LibreWolf)"
-
-        "workspace 5, class:(com.obsproject.Studio)"
-
-        "workspace 8, class:(com.github.wwmm.easyeffects)"
-        "workspace 8, class:(pavucontrol)"
-        "workspace 8, class:(org.pulseaudio.pavucontrol)"
-
-        "float, class:(steam), title:(Friends List)"
-        "float, class:(Tor Browser)"
-      ];
-      monitor = ",3440x1440@144.00Hz,auto,1.25";
-      exec-once = [
-        "xdg-open 'https://' &"
-        # "${config.settings.terminal} -e bluetui &"
-        # "${config.settings.terminal} -e wiremix &"
-        "${config.settings.terminal} &"
-      ];
 
       env = [
-        "XCURSOR_THEME,${cursor_name}"
-        "XCURSOR_SIZE,${cursor_size}"
-        "HYPRCURSOR_THEME,${cursor_name}"
-        "HYPRCURSOR_SIZE,${cursor_size}"
+        { _args = [ "XCURSOR_THEME" cursor_name ]; }
+        { _args = [ "XCURSOR_SIZE" cursor_size ]; }
+        { _args = [ "HYPRCURSOR_THEME" cursor_name ]; }
+        { _args = [ "HYPRCURSOR_SIZE" cursor_size ]; }
 
-        "XDG_CURRENT_DESKTOP,Hyprland"
-        "XDG_SESSION_TYPE,wayland"
-        "XDG_SESSION_DESKTOP,Hyprland"
-        "QT_QPA_PLATFORM,wayland;xcb"
-        "QT_QPA_PLATFORMTHEME,qt6ct"
-        "QT_WAYLAND_DISABLE_WINDOWDECORATION,1"
-        "QT_AUTO_SCREEN_SCALE_FACTOR,1"
-        "MOZ_ENABLE_WAYLAND,1"
-        "GDK_SCALE,1"
+        { _args = [ "XDG_CURRENT_DESKTOP" "Hyprland" ]; }
+        { _args = [ "XDG_SESSION_TYPE" "wayland" ]; }
+        { _args = [ "XDG_SESSION_DESKTOP" "Hyprland" ]; }
+        { _args = [ "QT_QPA_PLATFORM" "wayland;xcb" ]; }
+        { _args = [ "QT_QPA_PLATFORMTHEME" "qt6ct" ]; }
+        { _args = [ "QT_WAYLAND_DISABLE_WINDOWDECORATION" "1" ]; }
+        { _args = [ "QT_AUTO_SCREEN_SCALE_FACTOR" "1" ]; }
+        { _args = [ "MOZ_ENABLE_WAYLAND" "1" ]; }
+        { _args = [ "GDK_SCALE" "1" ]; }
 
-        "LIBVA_DRIVER_NAME,nvidia"
-        "__GLX_VENDOR_LIBRARY_NAME,nvidia"
-        "ELECTRON_OZONE_PLATFORM_HINT,auto"
+        { _args = [ "LIBVA_DRIVER_NAME" "nvidia" ]; }
+        { _args = [ "__GLX_VENDOR_LIBRARY_NAME" "nvidia" ]; }
+        { _args = [ "ELECTRON_OZONE_PLATFORM_HINT" "auto" ]; }
       ];
 
-      input = {
-        kb_layout = "us";
-        # kb_variant =
-        # kb_model =
-        # kb_options =
-        # kb_rules =
-
-        repeat_delay = 190;
-        repeat_rate = 200;
-
-        follow_mouse = 1;
-
-        touchpad = {
-          natural_scroll = false;
-        };
-
-        sensitivity = -0.6;
-        accel_profile = "flat";
-        scroll_points = "1 1";
+      monitor = {
+        output = "";
+        mode = "3440x1440@144.00Hz";
+        position = "auto";
+        scale = 1.25;
       };
 
-      general = {
-        # See https://wiki.hyprland.org/Configuring/Variables/ for more
-
-        gaps_in = 5;
-        gaps_out = 10;
-        border_size = 5;
-        "col.active_border" = "rgba(8a1671ff) rgba(8a132fff) 45deg";
-        "col.inactive_border" = "rgba(1c1b1c01)";
-
-        layout = "master";
-      };
-
-      decoration = {
-        # See https://wiki.hyprland.org/Configuring/Variables/ for more
-        shadow = {
+      animation = [
+        {
+          leaf = "workspaces";
+          enabled = true;
+          speed = 1;
+          curve = "default";
+        }
+        {
+          leaf = "windows";
           enabled = false;
-          range = 4;
-        };
-
-        rounding = 10;
-
-        blur = {
+        }
+        {
+          leaf = "fade";
           enabled = false;
-          size = 5;
-          passes = 3;
-          vibrancy = 0.5;
-        };
-      };
+        }
+      ];
 
-      animations = {
-        enabled = true;
-
-        # Some default animations, see https://wiki.hyprland.org/Configuring/Animations/ for more
-
-        # bezier = "myBezier, 0.05, 0.9, 0.1, 1.05";
-
-        animation = [
-          "workspaces, 1, 1, default"
-          "windows, 0"
-          "fade, 0"
+      on = {
+        _args = [
+          "hyprland.start"
+          (lib.generators.mkLuaInline ''
+            function()
+              hl.exec_cmd("${config.settings.terminal}")
+              hl.exec_cmd("xdg-open 'https://'")
+            end'')
         ];
       };
-
-      master = {
-        # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
-        new_status = "slave";
-      };
-
-      gestures = {
-        # See https://wiki.hyprland.org/Configuring/Variables/ for more
-        # workspace_swipe = false;
-      };
-
-      "$mod" = "SUPER";
-      "$smod" = "SUPER_SHIFT";
-      "$amod" = "SUPER_ALT";
-
-      bind = [
-        # run some applications
-        "$mod, P, exec, rofi -show drun"
-
-        "$amod, T, exec, firefox"
-        "$amod, S, exec, ${config.settings.terminal} -e vifm"
-        "$amod, R, exec, thunar"
-        "$amod, Z, exec, slurp | grim -g - - | wl-copy -t image/png"
-        ''$amod, X, exec, slurp | grim -g - -t png ~/Pictures/"$(date +'screenshot %y-%m-%d %H:%M:%S').png"''
-
-        "$amod, O, exec, poweroff"
-        "$amod, P, exec, hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 30% 0 && hyprctl dispatch moveactive 2000 2000"
-
-        "$smod, Q, exit,"
-
-        "$mod, Return, exec, ${config.settings.terminal}"
-
-        # window layouts
-        ''$mod, H, exec, if [ "$(hyprctl activewindow -j | jq -r '.floating')" = "false" ]; then hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 35% 35% && hyprctl dispatch movewindow r && hyprctl dispatch movewindow d && hyprctl dispatch pin active; else hyprctl dispatch togglefloating active && hyprctl dispatch pin active; fi''
-
-        "$mod, Q, fullscreenstate"
-        "$mod, W, fullscreen, 1"
-        "$mod, F, fullscreen, 0"
-        "$mod, G, killactive,"
-        "$mod, K, pin"
-
-        "$mod, H, pseudo, # dwindle"
-        "$mod, J, togglesplit, # dwindle"
-
-        # Move focus with mod + arrow keys
-        # "$mod, M, movefocus, l"
-        # "$mod, I, movefocus, r"
-        "$mod, N, cyclenext, next"
-        "$mod, N, bringactivetotop,"
-        "$mod, E, cyclenext, prev"
-        "$mod, E, bringactivetotop,"
-        "$mod, M, cyclenext, prev"
-        "$mod, M, bringactivetotop,"
-        "$mod, I, cyclenext, next"
-        "$mod, I, bringactivetotop,"
-
-        # Move focused window
-        "$smod, M, movewindow, l"
-        "$smod, I, movewindow, r"
-        "$smod, E, movewindow, u"
-        "$smod, N, movewindow, d"
-
-        # Switch workspaces with mod + [0-9]
-        "$mod, A, workspace, 1"
-        "$mod, R, workspace, 2"
-        "$mod, S, workspace, 3"
-        "$mod, T, workspace, 4"
-        "$mod, Z, workspace, 5"
-        "$mod, X, workspace, 6"
-        "$mod, C, workspace, 7"
-        "$mod, D, workspace, 8"
-        "$mod, 9, workspace, 9"
-        "$mod, 0, workspace, 10"
-
-        # Move active window to a workspace with mod + SHIFT + [0-9]
-        "$mod SHIFT, A, movetoworkspace, 1"
-        "$mod SHIFT, R, movetoworkspace, 2"
-        "$mod SHIFT, S, movetoworkspace, 3"
-        "$mod SHIFT, T, movetoworkspace, 4"
-        "$mod SHIFT, Z, movetoworkspace, 5"
-        "$mod SHIFT, X, movetoworkspace, 6"
-        "$mod SHIFT, C, movetoworkspace, 7"
-        "$mod SHIFT, D, movetoworkspace, 8"
-        "$mod SHIFT, 9, movetoworkspace, 9"
-        "$mod SHIFT, 0, movetoworkspace, 10"
-
-        # Scroll through existing workspaces with mod + scroll
-        "$mod, mouse_down, workspace, e+1"
-        "$mod, mouse_up, workspace, e-1"
-
-        # hyprwhspr-rs: hold ALT+N to dictate
-        "ALT, N, exec, hyprwhspr-rs record start"
-      ];
-
-      bindr = [
-        "ALT, N, exec, hyprwhspr-rs record stop"
-      ];
-
-      bindm = [
-        "$mod, mouse:272, movewindow"
-        "$mod, mouse:273, resizewindow"
-      ];
-
-      # "plugin:dynamic-cursors" = {
-      #   enabled = true;
-      #   mode = "none";
-      #   shake = {
-      #     enabled = true;
-      #     threshold = 0.5;
-      #     factor = 4;
-      #     effects = false;
-      #     nearest = true;
-      #     ipc = true;
-      #   };
-      # };
     };
+
+    extraConfig = builtins.readFile ./hyprland/binds.lua;
   };
 }

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   inputs,
+  pkgs,
   ...
 }:
 let
@@ -146,4 +147,12 @@ in
 
     extraConfig = builtins.readFile ./hyprland/binds.lua;
   };
+
+  home.file."Workspace/nixos/system/home-manager/applications/hyprland/.luarc.json".source =
+    pkgs.writeText "hyprland-luarc.json" (builtins.toJSON {
+      "$schema" = "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json";
+      "workspace.library" = [
+        "${config.settings.wm.package}/share/hypr/stubs"
+      ];
+    });
 }

--- a/system/home-manager/applications/hyprland/.luacheckrc
+++ b/system/home-manager/applications/hyprland/.luacheckrc
@@ -1,0 +1,1 @@
+globals = { "hl" }

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -42,7 +42,6 @@ hl.bind(mod .. " + G", hl.dsp.window.close())
 hl.bind(mod .. " + K", hl.dsp.window.pin())
 
 -- Layout (dwindle leftovers)
-hl.bind(mod .. " + H", hl.dsp.window.pseudo())
 hl.bind(mod .. " + J", hl.dsp.layout("togglesplit"))
 
 -- Cycle focus + bring to top

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -20,19 +20,32 @@ hl.window_rule({ match = { class = "Tor Browser" }, float = true })
 -- App launchers
 hl.bind(mod .. " + P", hl.dsp.exec_cmd("rofi -show drun"))
 hl.bind(amod .. " + T", hl.dsp.exec_cmd("firefox"))
-hl.bind(amod .. " + S", hl.dsp.exec_cmd("ghostty -e vifm"))
+hl.bind(amod .. " + S", hl.dsp.exec_cmd("kitty -e vifm"))
 hl.bind(amod .. " + R", hl.dsp.exec_cmd("thunar"))
 hl.bind(amod .. " + Z", hl.dsp.exec_cmd("slurp | grim -g - - | wl-copy -t image/png"))
-hl.bind(amod .. " + X", hl.dsp.exec_cmd([[slurp | grim -g - -t png ~/Pictures/"$(date +'screenshot %y-%m-%d %H:%M:%S').png"]]))
+hl.bind(
+	amod .. " + X",
+	hl.dsp.exec_cmd([[slurp | grim -g - -t png ~/Pictures/"$(date +'screenshot %y-%m-%d %H:%M:%S').png"]])
+)
 
 -- System
 hl.bind(amod .. " + O", hl.dsp.exec_cmd("poweroff"))
-hl.bind(amod .. " + P", hl.dsp.exec_cmd("hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 30% 0 && hyprctl dispatch moveactive 2000 2000"))
+hl.bind(
+	amod .. " + P",
+	hl.dsp.exec_cmd(
+		"hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 30% 0 && hyprctl dispatch moveactive 2000 2000"
+	)
+)
 hl.bind(smod .. " + Q", hl.dsp.exit())
 hl.bind(mod .. " + Return", hl.dsp.exec_cmd("ghostty"))
 
 -- Floating overlay toggle
-hl.bind(mod .. " + H", hl.dsp.exec_cmd([[if [ "$(hyprctl activewindow -j | jq -r '.floating')" = "false" ]; then hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 35% 35% && hyprctl dispatch movewindow r && hyprctl dispatch movewindow d && hyprctl dispatch pin active; else hyprctl dispatch togglefloating active && hyprctl dispatch pin active; fi]]))
+hl.bind(
+	mod .. " + H",
+	hl.dsp.exec_cmd(
+		[[if [ "$(hyprctl activewindow -j | jq -r '.floating')" = "false" ]; then hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 35% 35% && hyprctl dispatch movewindow r && hyprctl dispatch movewindow d && hyprctl dispatch pin active; else hyprctl dispatch togglefloating active && hyprctl dispatch pin active; fi]]
+	)
+)
 
 -- Fullscreen / window state
 hl.bind(mod .. " + Q", hl.dsp.window.fullscreen_state({ internal = 2, client = 0 }))
@@ -46,20 +59,20 @@ hl.bind(mod .. " + J", hl.dsp.layout("togglesplit"))
 
 -- Cycle focus + bring to top
 hl.bind(mod .. " + N", function()
-  hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
-  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+	hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
+	hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
 end)
 hl.bind(mod .. " + E", function()
-  hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
-  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+	hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
+	hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
 end)
 hl.bind(mod .. " + M", function()
-  hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
-  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+	hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
+	hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
 end)
 hl.bind(mod .. " + I", function()
-  hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
-  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+	hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
+	hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
 end)
 
 -- Move focused window

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -1,0 +1,106 @@
+local mod = "SUPER"
+local smod = "SUPER + SHIFT"
+local amod = "SUPER + ALT"
+
+-- Window rules
+hl.window_rule({ match = { class = "org.kde.digikam" }, workspace = "1" })
+hl.window_rule({ match = { class = "steam", float = false }, workspace = "2" })
+hl.window_rule({ match = { title = "Steam", float = false }, workspace = "2" })
+hl.window_rule({ match = { class = "Tor Browser" }, workspace = "3" })
+hl.window_rule({ match = { class = "obsidian" }, workspace = "3" })
+hl.window_rule({ match = { class = "firefox" }, workspace = "4" })
+hl.window_rule({ match = { class = "LibreWolf" }, workspace = "4" })
+hl.window_rule({ match = { class = "com.obsproject.Studio" }, workspace = "5" })
+hl.window_rule({ match = { class = "com.github.wwmm.easyeffects" }, workspace = "8" })
+hl.window_rule({ match = { class = "pavucontrol" }, workspace = "8" })
+hl.window_rule({ match = { class = "org.pulseaudio.pavucontrol" }, workspace = "8" })
+hl.window_rule({ match = { class = "steam", title = "Friends List" }, float = true })
+hl.window_rule({ match = { class = "Tor Browser" }, float = true })
+
+-- App launchers
+hl.bind(mod .. " + P", hl.dsp.exec_cmd("rofi -show drun"))
+hl.bind(amod .. " + T", hl.dsp.exec_cmd("firefox"))
+hl.bind(amod .. " + S", hl.dsp.exec_cmd("ghostty -e vifm"))
+hl.bind(amod .. " + R", hl.dsp.exec_cmd("thunar"))
+hl.bind(amod .. " + Z", hl.dsp.exec_cmd("slurp | grim -g - - | wl-copy -t image/png"))
+hl.bind(amod .. " + X", hl.dsp.exec_cmd([[slurp | grim -g - -t png ~/Pictures/"$(date +'screenshot %y-%m-%d %H:%M:%S').png"]]))
+
+-- System
+hl.bind(amod .. " + O", hl.dsp.exec_cmd("poweroff"))
+hl.bind(amod .. " + P", hl.dsp.exec_cmd("hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 30% 0 && hyprctl dispatch moveactive 2000 2000"))
+hl.bind(smod .. " + Q", hl.dsp.exit())
+hl.bind(mod .. " + Return", hl.dsp.exec_cmd("ghostty"))
+
+-- Floating overlay toggle
+hl.bind(mod .. " + H", hl.dsp.exec_cmd([[if [ "$(hyprctl activewindow -j | jq -r '.floating')" = "false" ]; then hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 35% 35% && hyprctl dispatch movewindow r && hyprctl dispatch movewindow d && hyprctl dispatch pin active; else hyprctl dispatch togglefloating active && hyprctl dispatch pin active; fi]]))
+
+-- Fullscreen / window state
+hl.bind(mod .. " + Q", hl.dsp.window.fullscreen_state({ internal = 2, client = 0 }))
+hl.bind(mod .. " + W", hl.dsp.window.fullscreen({ mode = "maximized" }))
+hl.bind(mod .. " + F", hl.dsp.window.fullscreen({ mode = "fullscreen" }))
+hl.bind(mod .. " + G", hl.dsp.window.close())
+hl.bind(mod .. " + K", hl.dsp.window.pin())
+
+-- Layout (dwindle leftovers)
+hl.bind(mod .. " + H", hl.dsp.window.pseudo())
+hl.bind(mod .. " + J", hl.dsp.layout("togglesplit"))
+
+-- Cycle focus + bring to top
+hl.bind(mod .. " + N", function()
+  hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
+  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+end)
+hl.bind(mod .. " + E", function()
+  hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
+  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+end)
+hl.bind(mod .. " + M", function()
+  hl.dispatch(hl.dsp.window.cycle_next({ next = false }))
+  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+end)
+hl.bind(mod .. " + I", function()
+  hl.dispatch(hl.dsp.window.cycle_next({ next = true }))
+  hl.dispatch(hl.dsp.window.alter_zorder({ mode = "top" }))
+end)
+
+-- Move focused window
+hl.bind(smod .. " + M", hl.dsp.window.move({ direction = "l" }))
+hl.bind(smod .. " + I", hl.dsp.window.move({ direction = "r" }))
+hl.bind(smod .. " + E", hl.dsp.window.move({ direction = "u" }))
+hl.bind(smod .. " + N", hl.dsp.window.move({ direction = "d" }))
+
+-- Switch workspaces
+hl.bind(mod .. " + A", hl.dsp.focus({ workspace = 1 }))
+hl.bind(mod .. " + R", hl.dsp.focus({ workspace = 2 }))
+hl.bind(mod .. " + S", hl.dsp.focus({ workspace = 3 }))
+hl.bind(mod .. " + T", hl.dsp.focus({ workspace = 4 }))
+hl.bind(mod .. " + Z", hl.dsp.focus({ workspace = 5 }))
+hl.bind(mod .. " + X", hl.dsp.focus({ workspace = 6 }))
+hl.bind(mod .. " + C", hl.dsp.focus({ workspace = 7 }))
+hl.bind(mod .. " + D", hl.dsp.focus({ workspace = 8 }))
+hl.bind(mod .. " + 9", hl.dsp.focus({ workspace = 9 }))
+hl.bind(mod .. " + 0", hl.dsp.focus({ workspace = 10 }))
+
+-- Move active window to a workspace
+hl.bind(smod .. " + A", hl.dsp.window.move({ workspace = 1 }))
+hl.bind(smod .. " + R", hl.dsp.window.move({ workspace = 2 }))
+hl.bind(smod .. " + S", hl.dsp.window.move({ workspace = 3 }))
+hl.bind(smod .. " + T", hl.dsp.window.move({ workspace = 4 }))
+hl.bind(smod .. " + Z", hl.dsp.window.move({ workspace = 5 }))
+hl.bind(smod .. " + X", hl.dsp.window.move({ workspace = 6 }))
+hl.bind(smod .. " + C", hl.dsp.window.move({ workspace = 7 }))
+hl.bind(smod .. " + D", hl.dsp.window.move({ workspace = 8 }))
+hl.bind(smod .. " + 9", hl.dsp.window.move({ workspace = 9 }))
+hl.bind(smod .. " + 0", hl.dsp.window.move({ workspace = 10 }))
+
+-- Mouse wheel workspace switching
+hl.bind(mod .. " + mouse_down", hl.dsp.focus({ workspace = "e+1" }))
+hl.bind(mod .. " + mouse_up", hl.dsp.focus({ workspace = "e-1" }))
+
+-- Mouse drag/resize
+hl.bind(mod .. " + mouse:272", hl.dsp.window.drag(), { mouse = true })
+hl.bind(mod .. " + mouse:273", hl.dsp.window.resize(), { mouse = true })
+
+-- hyprwhspr-rs: hold ALT+N to dictate
+hl.bind("ALT + N", hl.dsp.exec_cmd("hyprwhspr-rs record start"))
+hl.bind("ALT + N", hl.dsp.exec_cmd("hyprwhspr-rs record stop"), { release = true })

--- a/system/home-manager/applications/xdg.nix
+++ b/system/home-manager/applications/xdg.nix
@@ -132,7 +132,6 @@
       enable = true;
       configPackages = [ config.settings.wm.package ];
       extraPortals = with pkgs; [
-        xdg-desktop-portal-hyprland
         xdg-desktop-portal-gtk
       ];
     };

--- a/system/nixos/profile/desktop/ssh.nix
+++ b/system/nixos/profile/desktop/ssh.nix
@@ -9,7 +9,7 @@
 
       "codeberg.org ssh-ed25519" = {
         hostName = [ "codeberg.org" ];
-        publicKey = "SHA256:mIlxA9k46MmM6qdJOdMnAQpzGxF4WIVVL+fj+wZbw0g";
+        publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB";
       };
 
       "192.168.1.110 ssh-ed25519" = {

--- a/system/nixos/profile/desktop/ssh.nix
+++ b/system/nixos/profile/desktop/ssh.nix
@@ -6,10 +6,17 @@
         hostNames = [ "github.com" ];
         publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
       };
+
+      "codeberg.org ssh-ed25519" = {
+        hostName = [ "codeberg.org" ];
+        publicKey = "SHA256:mIlxA9k46MmM6qdJOdMnAQpzGxF4WIVVL+fj+wZbw0g";
+      };
+
       "192.168.1.110 ssh-ed25519" = {
         hostNames = [ "192.168.1.110 " ];
         publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHAsksMYthB3wMx9p1PQU/WNtVdfVt3dNXIE/CXUKB45";
       };
+
     };
   };
 }

--- a/system/nixos/profile/desktop/ssh.nix
+++ b/system/nixos/profile/desktop/ssh.nix
@@ -8,7 +8,7 @@
       };
 
       "codeberg.org ssh-ed25519" = {
-        hostName = [ "codeberg.org" ];
+        hostNames = [ "codeberg.org" ];
         publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB";
       };
 


### PR DESCRIPTION
## Summary
- Hyprland 0.55 deprecated hyprlang in favor of Lua config. This PR migrates the desktop profile to `configType = "lua"`, bumps the package to `pkgs-unstable.hyprland`, and overrides the HM Hyprland module with the master branch (where the Lua renderer lives) — scoped to this module only so the rest of the HM stack stays on `release-25.11`.
- Config is split: Nix `settings` owns config blocks, env, monitor, animations, and the `hyprland.start` autostart hook (with `settings.terminal` still interpolated from Nix); `extraConfig = builtins.readFile ./hyprland/binds.lua` holds the new Lua file for binds and window rules.
- Every hyprlang bind/dispatcher/window rule is translated to its `hl.*` Lua equivalent (`hl.dsp.exec_cmd`, `hl.dsp.window.fullscreen`, `hl.dsp.focus`, `hl.window_rule`, etc.). Mouse binds use `{ mouse = true }`, bindr → `{ release = true }`.

## Test plan
- [ ] `nix flake check` passes
- [ ] `nixos-rebuild build --flake .#desktop` succeeds
- [ ] `nixos-rebuild switch --flake .#desktop` activates without WM crash
- [ ] Inspect `~/.config/hypr/hyprland.lua` and confirm structure
- [ ] Live keybind smoke test: workspace switching (`SUPER + A/R/S/...`), launchers (`SUPER + Return` → ghostty, `SUPER + P` → rofi), window mgmt (`SUPER + Q/W/F/G/K`), mouse drag/resize (`SUPER + LMB/RMB`), hyprwhspr push-to-talk (`ALT + N` hold)
- [ ] Verify window rules send apps to correct workspaces (digikam → 1, steam → 2, firefox/librewolf → 4, etc.)
- [ ] Verify autostart fires `ghostty` (or whatever `settings.terminal` resolves to) on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)