### PR TITLE
feat(terminal): make kitty the real default

### DIFF
--- a/profile/common/options.nix
+++ b/profile/common/options.nix
@@ -20,6 +20,5 @@
       name = "Tela-circle-dark";
       package = pkgs.tela-circle-icon-theme;
     };
-    terminal = "kitty";
   };
 }

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -143,6 +143,15 @@ in
             end'')
         ];
       };
+
+      bind = [
+        {
+          _args = [
+            "SUPER + Return"
+            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("${config.settings.terminal}")'')
+          ];
+        }
+      ];
     };
 
     extraConfig = builtins.readFile ./hyprland/binds.lua;

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -37,7 +37,6 @@ hl.bind(
 	)
 )
 hl.bind(smod .. " + Q", hl.dsp.exit())
-hl.bind(mod .. " + Return", hl.dsp.exec_cmd("ghostty"))
 
 -- Floating overlay toggle
 hl.bind(

--- a/system/options.nix
+++ b/system/options.nix
@@ -68,7 +68,7 @@ with lib;
     };
     terminal = mkOption {
       type = types.str;
-      default = "ghostty";
+      default = "kitty";
       description = "Default terminal emulator to use.";
     };
     storagePath = mkOption {


### PR DESCRIPTION
## Summary
- Flip `settings.terminal` default to `"kitty"` and drop the now-redundant override in `profile/common/options.nix` so the option default is the single source of truth.
- Move `SUPER + Return` out of the static `binds.lua` and into `hyprland.nix` as `settings.bind` so it interpolates `config.settings.terminal` instead of hardcoding a name.
- Remove the `hl.bind(mod .. " + Return", hl.dsp.exec_cmd("ghostty"))` line from `binds.lua` to avoid duplicate registration.

Closes #15.

## Notes
- The PRD wrote the new bind as `"SUPER, Return, exec, ${config.settings.terminal}"` (hyprlang syntax). This module uses `configType = "lua"`, so I used the `_args` form documented in the home-manager-master lua-mode example, which renders to `hl.bind("SUPER + Return", hl.dsp.exec_cmd("kitty"))` — same intent, correct syntax for this codebase.
- `amod + S` (vifm) was already `kitty -e vifm` on `main`, so no change there — covered by the PRD's "leave alone".

## Test plan
- [x] `nix eval` of `nixosConfigurations.desktop.config.settings.terminal` → `"kitty"`.
- [x] Inspected generated `hyprland.lua`: contains `hl.bind("SUPER + Return", (hl.dsp.exec_cmd("kitty")))`; old ghostty bind line is gone; autostart still calls `kitty`; `amod + S` still launches `kitty -e vifm`.
- [ ] On the real desktop host: `nixos-rebuild switch` + Hyprland relaunch; press `SUPER + Return` (expect kitty), confirm autostart opens kitty, confirm `amod + S` opens kitty+vifm, confirm `ghostty &` from a shell still works.
- [ ] `echo $TERM` unchanged from current value.

> Disk in this dev VM was at 100%, so a full `nixos-rebuild build` could not complete here — the failure was the kernel/derivation OOSpace, not the configuration. Eval-level verification above covers what would otherwise have been the build's correctness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)