### PR TITLE
fix(hyprpaper): use flat key=value config, add preload

### DIFF
--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -20,12 +20,8 @@ in
     enable = true;
     settings = {
       splash = false;
-
-      wallpaper = {
-        monitor = "";
-        path = "~/.wallpaper/wallpaper";
-        fit_mode = "cover";
-      };
+      preload = [ "~/.wallpaper/wallpaper" ];
+      wallpaper = [ ",~/.wallpaper/wallpaper" ];
     };
   };
 


### PR DESCRIPTION
The previous attrset form rendered as a Hyprland-style block (`wallpaper { ... }`), which hyprpaper cannot parse. preload was also missing, which hyprpaper requires before any wallpaper line takes effect.