### PR TITLE
fix(hyprland): rewrite SUPER+H overlay in native Lua

### DIFF
--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -50,7 +50,7 @@ hl.bind(mod .. " + H", function()
 		hl.dispatch(hl.dsp.window.pin({ action = "toggle" }))
 	else
 		local mon = hl.get_active_monitor()
-		local w = math.floor((mon and mon.width or 1920) * 0.25)
+		local w = math.floor((mon and mon.width or 1920) * 0.20)
 		local h = math.floor(w * 9 / 16)
 		hl.dispatch(hl.dsp.window.float({ action = "toggle" }))
 		hl.dispatch(hl.dsp.window.resize({ x = w, y = h }))

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -51,7 +51,7 @@ hl.bind(mod .. " + H", function()
 	else
 		local mon = hl.get_active_monitor()
 		local w = math.floor((mon and mon.width or 1920) * 0.35)
-		local h = math.floor((mon and mon.height or 1080) * 0.35)
+		local h = math.floor(w * 9 / 16)
 		hl.dispatch(hl.dsp.window.float({ action = "toggle" }))
 		hl.dispatch(hl.dsp.window.resize({ x = w, y = h }))
 		hl.dispatch(hl.dsp.window.move({ direction = "r" }))

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -50,7 +50,7 @@ hl.bind(mod .. " + H", function()
 		hl.dispatch(hl.dsp.window.pin({ action = "toggle" }))
 	else
 		local mon = hl.get_active_monitor()
-		local w = math.floor((mon and mon.width or 1920) * 0.35)
+		local w = math.floor((mon and mon.width or 1920) * 0.25)
 		local h = math.floor(w * 9 / 16)
 		hl.dispatch(hl.dsp.window.float({ action = "toggle" }))
 		hl.dispatch(hl.dsp.window.resize({ x = w, y = h }))

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -39,12 +39,26 @@ hl.bind(
 hl.bind(smod .. " + Q", hl.dsp.exit())
 
 -- Floating overlay toggle
-hl.bind(
-	mod .. " + H",
-	hl.dsp.exec_cmd(
-		[[if [ "$(hyprctl activewindow -j | jq -r '.floating')" = "false" ]; then hyprctl dispatch togglefloating active && hyprctl dispatch resizeactive exact 35% 35% && hyprctl dispatch movewindow r && hyprctl dispatch movewindow d && hyprctl dispatch pin active; else hyprctl dispatch togglefloating active && hyprctl dispatch pin active; fi]]
-	)
-)
+hl.bind(mod .. " + H", function()
+	local win = hl.get_active_window()
+	if not win then
+		return
+	end
+
+	if win.floating then
+		hl.dispatch(hl.dsp.window.float({ action = "toggle" }))
+		hl.dispatch(hl.dsp.window.pin({ action = "toggle" }))
+	else
+		local mon = hl.get_active_monitor()
+		local w = math.floor((mon and mon.width or 1920) * 0.35)
+		local h = math.floor((mon and mon.height or 1080) * 0.35)
+		hl.dispatch(hl.dsp.window.float({ action = "toggle" }))
+		hl.dispatch(hl.dsp.window.resize({ x = w, y = h }))
+		hl.dispatch(hl.dsp.window.move({ direction = "r" }))
+		hl.dispatch(hl.dsp.window.move({ direction = "d" }))
+		hl.dispatch(hl.dsp.window.pin({ action = "toggle" }))
+	end
+end)
 
 -- Fullscreen / window state
 hl.bind(mod .. " + Q", hl.dsp.window.fullscreen_state({ internal = 2, client = 0 }))


### PR DESCRIPTION
The shell-based `hl.dsp.exec_cmd("if [...] ; then hyprctl dispatch ... fi")` binding became silently inert after the hyprlang → Lua migration. Replace it with native dispatchers driven from `hl.get_active_window()`, so the toggle runs in-process without forking sh or piping through jq.