### PR TITLE
fix(homelab): use podman --tz=local for all containers

### DIFF
--- a/system/home-manager/homelab/entertainment/jellyfin.nix
+++ b/system/home-manager/homelab/entertainment/jellyfin.nix
@@ -25,8 +25,9 @@ with lib;
       environment = {
         PUID = 1000;
         PGID = 1000;
-        TZ = Etc/UTC;
       };
+
+      extraPodmanArgs = [ "--tz=local" ];
 
       ports = [
         "8096:8096"

--- a/system/home-manager/homelab/entertainment/prowlarr.nix
+++ b/system/home-manager/homelab/entertainment/prowlarr.nix
@@ -21,8 +21,9 @@ with lib;
       environment = {
         PUID = 1000;
         PGID = 1000;
-        TZ = Etc/UTC;
       };
+
+      extraPodmanArgs = [ "--tz=local" ];
 
       ports = [
         "9696:9696"
@@ -37,8 +38,9 @@ with lib;
         LOG_LEVEL = "info";
         LOG_HTML = "false";
         CAPTCHA_SOLVER = "none";
-        TZ = "Etc/UTC";
       };
+
+      extraPodmanArgs = [ "--tz=local" ];
     };
   };
 }

--- a/system/home-manager/homelab/entertainment/qbittorrent.nix
+++ b/system/home-manager/homelab/entertainment/qbittorrent.nix
@@ -35,6 +35,7 @@ with lib;
       ];
 
       extraPodmanArgs = [
+        "--tz=local"
         "--read-only"
         "--tmpfs /tmp:ro"
         "--stop-timeout 1800"

--- a/system/home-manager/homelab/entertainment/radarr.nix
+++ b/system/home-manager/homelab/entertainment/radarr.nix
@@ -28,8 +28,9 @@ with lib;
       environment = {
         PUID = 1000;
         PGID = 1000;
-        TZ = Etc/UTC;
       };
+
+      extraPodmanArgs = [ "--tz=local" ];
 
       ports = [
         "7878:7878"

--- a/system/home-manager/homelab/entertainment/sonarr.nix
+++ b/system/home-manager/homelab/entertainment/sonarr.nix
@@ -28,8 +28,9 @@ with lib;
       environment = {
         PUID = 1000;
         PGID = 1000;
-        TZ = Etc/UTC;
       };
+
+      extraPodmanArgs = [ "--tz=local" ];
 
       ports = [
         "8989:8989"

--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -61,7 +61,6 @@ with lib;
 
       # Volume mounts
       volumes = [
-        "/etc/localtime:/etc/localtime:ro"
         "${data_path}/config:/config/db:Z"
         "${storage_path}/media:/media/frigate:Z"
         "${model}:/data/models/model.tflite"
@@ -71,11 +70,8 @@ with lib;
         "/home/s1n7ax/labels.txt:/data/labels.txt"
       ];
 
-      environment = {
-        TZ = "Asia/Colombo";
-      };
-
       extraPodmanArgs = [
+        "--tz=local"
         "--shm-size=1024m"
         "--mount=type=tmpfs,target=/tmp/cache,tmpfs-size=1000000000"
         "--group-add=keep-groups"

--- a/system/home-manager/homelab/home-assistant.nix
+++ b/system/home-manager/homelab/home-assistant.nix
@@ -25,9 +25,9 @@ with lib;
       ];
       volumes = [
         "${data_path}:/config"
-        "/etc/localtime:/etc/localtime:ro"
         "/run/dbus:/run/dbus:ro"
       ];
+      extraPodmanArgs = [ "--tz=local" ];
       ports = [ "8124:8123" ];
       addCapabilities = [
         "NET_ADMIN"

--- a/system/home-manager/homelab/homepage.nix
+++ b/system/home-manager/homelab/homepage.nix
@@ -307,6 +307,8 @@ with lib;
 
       ports = [ "3001:3000" ];
 
+      extraPodmanArgs = [ "--tz=local" ];
+
       environment = {
         HOMEPAGE_ALLOWED_HOSTS = "192.168.1.110:3001,localhost:3001,gethomepage.dev";
         PUID = "1000";

--- a/system/home-manager/homelab/mqtt.nix
+++ b/system/home-manager/homelab/mqtt.nix
@@ -27,6 +27,7 @@ with lib;
         "${data_path}/config:/mosquitto/config"
         "${data_path}/data:/mosquitto/data"
       ];
+      extraPodmanArgs = [ "--tz=local" ];
       exec = "mosquitto -c /mosquitto-no-auth.conf";
     };
   };

--- a/system/home-manager/homelab/node-red.nix
+++ b/system/home-manager/homelab/node-red.nix
@@ -19,11 +19,9 @@ with lib;
       ports = [
         "1880:1880"
       ];
-      environment = {
-        TZ = config.home.timeZone or "UTC";
-      };
       extraPodmanArgs = [
         "--userns=keep-id"
+        "--tz=local"
       ];
       volumes = [
         "${config.home.homeDirectory}/.homelab/node-red:/data:Z"

--- a/system/home-manager/homelab/pairdrop.nix
+++ b/system/home-manager/homelab/pairdrop.nix
@@ -18,8 +18,8 @@ with lib;
       environment = {
         PUID = "1000";
         PGID = "1000";
-        TZ = config.home.timeZone or "UTC";
       };
+      extraPodmanArgs = [ "--tz=local" ];
       volumes = [
         "${config.home.homeDirectory}/.homelab/pairdrop:/config:Z"
       ];

--- a/system/home-manager/homelab/z2m.nix
+++ b/system/home-manager/homelab/z2m.nix
@@ -58,6 +58,7 @@ with lib;
       ];
       extraPodmanArgs = [
         "--group-add=keep-groups"
+        "--tz=local"
       ];
       devices = [
         "/dev/ttyUSB0:/dev/ttyUSB0"


### PR DESCRIPTION
Replace TZ env vars and /etc/localtime volume mounts with the native podman --tz=local flag so all containers inherit the host timezone.