### PR TITLE
feat(dev-vm): enable devcontainer CLI

### DIFF
--- a/profile/dev-vm/options.nix
+++ b/profile/dev-vm/options.nix
@@ -39,6 +39,7 @@
       web.enable = true;
       ide.enable = true;
       ci.enable = true;
+      virtualization.enable = true;
     };
   };
 }


### PR DESCRIPTION
Turn on development.virtualization in the dev-vm profile so the devcontainer CLI (and related container tooling) is available inside the microvm.