### PR TITLE
feat(hyprland): add animated waveform indicator for voice dictation

### DIFF
--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -8,8 +8,11 @@
 let
   cursor_name = config.settings.cursor.name;
   cursor_size = config.settings.cursor.size;
+  voice-indicator = pkgs.callPackage ./hyprland/voice-indicator { };
 in
 {
+  home.packages = [ voice-indicator ];
+
   disabledModules = [ "services/window-managers/hyprland.nix" ];
 
   imports = [

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -126,6 +126,13 @@ hl.bind(mod .. " + mouse_up", hl.dsp.focus({ workspace = "e-1" }))
 hl.bind(mod .. " + mouse:272", hl.dsp.window.drag(), { mouse = true })
 hl.bind(mod .. " + mouse:273", hl.dsp.window.resize(), { mouse = true })
 
--- hyprwhspr-rs: hold ALT+N to dictate
-hl.bind("ALT + K", hl.dsp.exec_cmd("hyprwhspr-rs record start"))
-hl.bind("ALT + K", hl.dsp.exec_cmd("hyprwhspr-rs record stop"), { release = true })
+-- hyprwhspr-rs: hold ALT+K to dictate, with on-screen waveform indicator
+hl.bind(
+	"ALT + K",
+	hl.dsp.exec_cmd("sh -c 'pkill -x voice-indicator; voice-indicator & hyprwhspr-rs record start'")
+)
+hl.bind(
+	"ALT + K",
+	hl.dsp.exec_cmd("sh -c 'hyprwhspr-rs record stop; pkill -x voice-indicator'"),
+	{ release = true }
+)

--- a/system/home-manager/applications/hyprland/binds.lua
+++ b/system/home-manager/applications/hyprland/binds.lua
@@ -129,10 +129,12 @@ hl.bind(mod .. " + mouse:273", hl.dsp.window.resize(), { mouse = true })
 -- hyprwhspr-rs: hold ALT+K to dictate, with on-screen waveform indicator
 hl.bind(
 	"ALT + K",
-	hl.dsp.exec_cmd("sh -c 'pkill -x voice-indicator; voice-indicator & hyprwhspr-rs record start'")
+	hl.dsp.exec_cmd(
+		"sh -c 'pkill -f \"[v]oice-indicator/main.py\"; voice-indicator & hyprwhspr-rs record start'"
+	)
 )
 hl.bind(
 	"ALT + K",
-	hl.dsp.exec_cmd("sh -c 'hyprwhspr-rs record stop; pkill -x voice-indicator'"),
+	hl.dsp.exec_cmd("sh -c 'hyprwhspr-rs record stop; pkill -f \"[v]oice-indicator/main.py\"'"),
 	{ release = true }
 )

--- a/system/home-manager/applications/hyprland/voice-indicator/default.nix
+++ b/system/home-manager/applications/hyprland/voice-indicator/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  runCommand,
+  makeWrapper,
+  python3,
+  gtk4,
+  gtk4-layer-shell,
+  gobject-introspection,
+  glib,
+  pango,
+  gdk-pixbuf,
+  graphene,
+  harfbuzz,
+  librsvg,
+}:
+let
+  pythonEnv = python3.withPackages (ps: [
+    ps.pygobject3
+    ps.pycairo
+  ]);
+
+  typelibDirs = map (p: "${lib.getLib p}/lib/girepository-1.0") [
+    gtk4
+    gtk4-layer-shell
+    gobject-introspection
+    glib
+    pango
+    gdk-pixbuf
+    graphene
+    harfbuzz
+    librsvg
+  ];
+in
+runCommand "voice-indicator"
+  {
+    nativeBuildInputs = [ makeWrapper ];
+  }
+  ''
+    install -Dm644 ${./main.py} $out/share/voice-indicator/main.py
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/voice-indicator \
+      --add-flags $out/share/voice-indicator/main.py \
+      --prefix GI_TYPELIB_PATH : "${lib.concatStringsSep ":" typelibDirs}" \
+      --prefix LD_PRELOAD : "${lib.getLib gtk4-layer-shell}/lib/libgtk4-layer-shell.so"
+  ''

--- a/system/home-manager/applications/hyprland/voice-indicator/main.py
+++ b/system/home-manager/applications/hyprland/voice-indicator/main.py
@@ -22,10 +22,6 @@ window { background: transparent; }
     border: 1px solid rgba(255, 80, 80, 0.55);
     box-shadow: 0 8px 28px rgba(0, 0, 0, 0.55);
 }
-.mic {
-    font-size: 22px;
-    margin-right: 14px;
-}
 """
 
 WAVE_WIDTH = 240
@@ -94,9 +90,6 @@ def on_activate(app: Gtk.Application) -> None:
     box.set_halign(Gtk.Align.CENTER)
     box.set_valign(Gtk.Align.CENTER)
 
-    mic = Gtk.Label(label="\U0001f3a4")
-    mic.add_css_class("mic")
-    box.append(mic)
     box.append(Waveform())
 
     win.set_child(box)

--- a/system/home-manager/applications/hyprland/voice-indicator/main.py
+++ b/system/home-manager/applications/hyprland/voice-indicator/main.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import math
+import signal
+import sys
+
+import cairo
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Gdk", "4.0")
+gi.require_version("Gtk4LayerShell", "1.0")
+
+from gi.repository import Gdk, GLib, Gtk
+from gi.repository import Gtk4LayerShell as LayerShell
+
+CSS = b"""
+window { background: transparent; }
+.indicator {
+    background: rgba(18, 18, 22, 0.88);
+    border-radius: 28px;
+    padding: 10px 22px;
+    border: 1px solid rgba(255, 80, 80, 0.55);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.55);
+}
+.mic {
+    font-size: 22px;
+    margin-right: 14px;
+}
+"""
+
+WAVE_WIDTH = 240
+WAVE_HEIGHT = 36
+
+
+class Waveform(Gtk.DrawingArea):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_content_width(WAVE_WIDTH)
+        self.set_content_height(WAVE_HEIGHT)
+        self.phase = 0.0
+        self._last_us: int | None = None
+        self.set_draw_func(self._draw)
+        self.add_tick_callback(self._tick)
+
+    def _tick(self, _widget, frame_clock) -> bool:
+        now = frame_clock.get_frame_time()
+        if self._last_us is None:
+            self._last_us = now
+        dt = (now - self._last_us) / 1_000_000.0
+        self._last_us = now
+        self.phase += dt * 5.5
+        self.queue_draw()
+        return GLib.SOURCE_CONTINUE
+
+    def _draw(self, _area, cr, width: int, height: int) -> None:
+        cy = height / 2
+        cr.set_line_width(2.4)
+        cr.set_line_cap(1)
+        cr.set_line_join(1)
+
+        steps = max(width, 1)
+        cr.move_to(0, cy)
+        for i in range(steps + 1):
+            t = i / steps
+            envelope = math.sin(math.pi * t)
+            amp = (height * 0.42) * envelope * (
+                0.62 * math.sin(2 * math.pi * 1.6 * t + self.phase)
+                + 0.38 * math.sin(2 * math.pi * 3.1 * t - self.phase * 1.7)
+            )
+            cr.line_to(i, cy + amp)
+
+        grad = cairo.LinearGradient(0, 0, width, 0)
+        grad.add_color_stop_rgba(0.0, 1.0, 0.32, 0.32, 0.0)
+        grad.add_color_stop_rgba(0.15, 1.0, 0.32, 0.32, 1.0)
+        grad.add_color_stop_rgba(0.85, 1.0, 0.55, 0.32, 1.0)
+        grad.add_color_stop_rgba(1.0, 1.0, 0.32, 0.32, 0.0)
+        cr.set_source(grad)
+        cr.stroke()
+
+
+def on_activate(app: Gtk.Application) -> None:
+    win = Gtk.ApplicationWindow(application=app)
+    win.set_decorated(False)
+    win.add_css_class("voice-indicator-window")
+
+    LayerShell.init_for_window(win)
+    LayerShell.set_layer(win, LayerShell.Layer.OVERLAY)
+    LayerShell.set_anchor(win, LayerShell.Edge.BOTTOM, True)
+    LayerShell.set_margin(win, LayerShell.Edge.BOTTOM, 80)
+    LayerShell.set_namespace(win, "voice-indicator")
+
+    box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+    box.add_css_class("indicator")
+    box.set_halign(Gtk.Align.CENTER)
+    box.set_valign(Gtk.Align.CENTER)
+
+    mic = Gtk.Label(label="\U0001f3a4")
+    mic.add_css_class("mic")
+    box.append(mic)
+    box.append(Waveform())
+
+    win.set_child(box)
+
+    css = Gtk.CssProvider()
+    css.load_from_data(CSS)
+    Gtk.StyleContext.add_provider_for_display(
+        Gdk.Display.get_default(),
+        css,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+    )
+
+    win.present()
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+    app = Gtk.Application(application_id="dev.s1n7ax.voice-indicator")
+    app.connect("activate", on_activate)
+    return app.run([])
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a GTK4 layer-shell overlay that pops up at the bottom-center of the screen while ALT+K is held, so it's obvious when `hyprwhspr-rs` is actively recording.
- The indicator is a small mic + Cairo-drawn flowing waveform animated via a GTK frame-clock tick; packaged as a `voice-indicator` derivation and added to `home.packages`.
- `binds.lua` is updated so ALT+K press spawns `voice-indicator` alongside `hyprwhspr-rs record start`, and release stops dictation then `pkill`s the indicator.

## Test plan
- [ ] `nixos-rebuild switch` (or `home-manager switch`) applies cleanly
- [ ] Hold ALT+K — waveform appears at bottom-center, animates smoothly
- [ ] Release ALT+K — indicator disappears immediately and dictated text is inserted as before
- [ ] Repeated press/release does not leave stale `voice-indicator` processes (the press handler `pkill`s any pre-existing instance)