### PR TITLE
feat(xdg): add GitHub Pull Requests desktop app

### DIFF
--- a/system/home-manager/applications/xdg.nix
+++ b/system/home-manager/applications/xdg.nix
@@ -64,6 +64,16 @@
           "Development"
         ];
       };
+      github-pulls = {
+        name = "GitHub Pull Requests";
+        exec = "${pkgs.google-chrome}/bin/google-chrome-stable --app=https://github.com/pulls";
+        icon = "github";
+        terminal = false;
+        categories = [
+          "Network"
+          "Development"
+        ];
+      };
       sinhala-unicode = {
         name = "Sinhala Unicode";
         exec = "${pkgs.google-chrome}/bin/google-chrome-stable --app=https://www.sinhalaunicode.org/";


### PR DESCRIPTION
## Summary
- Add `github-pulls` desktop entry that opens https://github.com/pulls as a Chrome app, mirroring the existing WhatsApp/GitHub entries.

Closes #29