### PR TITLE
feat(frigate): enable Frigate+ via PLUS_API_KEY

### DIFF
--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -68,8 +68,6 @@ with lib;
         "${model}:/data/models/model.tflite"
         "${model_label}:/data/models/labels.txt"
         "${config.sops.templates."frigate-config.yml".path}:/config/config.yaml:ro"
-        "/home/s1n7ax/yolo_nas.onnx:/data/yolo_nas.onnx"
-        "/home/s1n7ax/labels.txt:/data/labels.txt"
       ];
 
       extraPodmanArgs = [
@@ -145,13 +143,7 @@ with lib;
         #                               MODEL                                #
         #--------------------------------------------------------------------#
         model:
-          model_type: yolonas
-          width: 320
-          height: 320
-          input_tensor: nchw
-          input_pixel_format: bgr
-          path: /data/yolo_nas.onnx
-          labelmap_path: /data/labels.txt
+          path: plus://ed95518dfd5207502f94650c55993fb0
 
         #--------------------------------------------------------------------#
         #                               DETECT                               #

--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -24,6 +24,8 @@ in
 with lib;
 {
   config = mkIf config.features.homelab.frigate.enable {
+    sops.secrets."frigate/plus/api_key" = { };
+
     systemd.user.tmpfiles.rules = [
       "d %h/.homelab/frigate 0700 - - -"
       "d %h/.homelab/frigate/media 0700 - - -"
@@ -75,8 +77,15 @@ with lib;
         "--shm-size=1024m"
         "--mount=type=tmpfs,target=/tmp/cache,tmpfs-size=1000000000"
         "--group-add=keep-groups"
+        "--env-file=${config.sops.templates."frigate.env".path}"
       ];
       autoStart = true;
+    };
+
+    sops.templates."frigate.env" = {
+      content = ''
+        PLUS_API_KEY=${config.sops.placeholder."frigate/plus/api_key"}
+      '';
     };
 
     sops.templates."frigate-config.yml" = {

--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -68,6 +68,8 @@ with lib;
         "${model}:/data/models/model.tflite"
         "${model_label}:/data/models/labels.txt"
         "${config.sops.templates."frigate-config.yml".path}:/config/config.yaml:ro"
+        # "/home/s1n7ax/yolo_nas.onnx:/data/yolo_nas.onnx"
+        # "/home/s1n7ax/labels.txt:/data/labels.txt"
       ];
 
       extraPodmanArgs = [


### PR DESCRIPTION
## Summary
- Frigate+ requires `PLUS_API_KEY` as a container env var (per [docs](https://docs.frigate.video/integrations/plus)); it cannot be set in `config.yaml` or via the `environment_vars` section.
- Renders the key from sops (`frigate/plus/api_key`) into a `frigate.env` template and mounts it via podman's `--env-file` so the secret never leaks into the nix store.
- Once the secret is present, set `model.path: plus://<model_id>` in the Frigate config to actually use a trained Frigate+ model.

## Follow-up
- Add `frigate/plus/api_key` to the `nix-secrets` repo and `nix flake update secrets` (the locked rev does not include it yet).

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] `/run/user/1000/secrets-rendered/frigate.env` contains `PLUS_API_KEY=...`
- [ ] Frigate container starts; UI shows "Send to Frigate+" enabled in snapshots