### PR TITLE
feat(dev-vm): add persistent volume for /var/lib/docker

### DIFF
--- a/system/nixos/utils/microvm.nix
+++ b/system/nixos/utils/microvm.nix
@@ -60,6 +60,13 @@ with lib;
                 autoCreate = true;
               }
               {
+                mountPoint = "/var/lib/docker";
+                image = "/var/lib/microvms/dev-vm/docker.img";
+                size = 20480;
+                fsType = "ext4";
+                autoCreate = true;
+              }
+              {
                 mountPoint = "/persist/ssh-host-keys";
                 image = "/var/lib/microvms/dev-vm/ssh-host-keys.img";
                 size = 64;


### PR DESCRIPTION
## Summary
- Adds a 20G persistent volume (`docker.img`) mounted at `/var/lib/docker` in the dev-vm microvm
- Fixes docker images and compose named volumes (including postgres data) being wiped on every VM reboot, since `/var/lib/docker` previously lived on the tmpfs root

## Test plan
- [x] `nix eval .#nixosConfigurations.desktop.config.microvm.vms.dev-vm.config.config.microvm.volumes` shows the new volume
- [ ] On host: `nixos-rebuild switch` + `systemctl restart microvm@dev-vm.service`
- [ ] In VM: `docker compose up -d`, reboot VM, confirm images and postgres data survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)