### PR TITLE
feat(alias): allow OSC 52 clipboard reads in dev VM kitty window

### DIFF
--- a/system/home-manager/applications/alias.nix
+++ b/system/home-manager/applications/alias.nix
@@ -2,7 +2,9 @@
 let
   alias = {
     # ssh
-    dev = "kitty +kitten ssh dev";
+    # allow silent OSC 52 clipboard reads only in this window so "+p works in
+    # remote nvim; other kitty windows keep the default read-clipboard-ask
+    dev = "kitty -o clipboard_control='write-clipboard write-primary read-clipboard read-primary' +kitten ssh dev";
 
     # kubectl
     k = "kubectl";


### PR DESCRIPTION
## Summary
- Pass `-o clipboard_control='write-clipboard write-primary read-clipboard read-primary'` in the `dev` alias so OSC 52 clipboard reads work without a prompt in the dev-VM kitty window, enabling `"+p` from the host clipboard in remote nvim.
- Other kitty windows keep the default `read-clipboard-ask` policy.

Pairs with s1n7ax/nvim PR enabling the OSC 52 clipboard provider over SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)