### PR TITLE
fix(kitty): move ctrl+c keybinding out of settings block

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,10 +215,10 @@
     "secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1779766061,
-        "narHash": "sha256-jm+AqXi1jGKAxbk6MawbUBspsePZDB5p0qz4r98Ybi0=",
+        "lastModified": 1780888618,
+        "narHash": "sha256-K2u+tTLt4CfJo9qSxMEssSNXtHGt0Q9hh959CF7Su5c=",
         "ref": "main",
-        "rev": "83d25d9060bdd95e012665664aa7253b36740eb8",
+        "rev": "551552213fe486031cad6ac3674eff6aa5d800f8",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/s1n7ax/nix-secrets.git"

--- a/system/home-manager/applications/alias.nix
+++ b/system/home-manager/applications/alias.nix
@@ -2,9 +2,7 @@
 let
   alias = {
     # ssh
-    # allow silent OSC 52 clipboard reads only in this window so "+p works in
-    # remote nvim; other kitty windows keep the default read-clipboard-ask
-    dev = "kitty -o clipboard_control='write-clipboard write-primary read-clipboard read-primary' kitten ssh dev";
+    dev = "kitten ssh dev";
 
     # kubectl
     k = "kubectl";

--- a/system/home-manager/applications/alias.nix
+++ b/system/home-manager/applications/alias.nix
@@ -4,7 +4,7 @@ let
     # ssh
     # allow silent OSC 52 clipboard reads only in this window so "+p works in
     # remote nvim; other kitty windows keep the default read-clipboard-ask
-    dev = "kitty -o clipboard_control='write-clipboard write-primary read-clipboard read-primary' +kitten ssh dev";
+    dev = "kitty -o clipboard_control='write-clipboard write-primary read-clipboard read-primary' kitten ssh dev";
 
     # kubectl
     k = "kubectl";

--- a/system/home-manager/applications/kitty.nix
+++ b/system/home-manager/applications/kitty.nix
@@ -28,6 +28,7 @@ in
       cursor_trail_decay = "0 0.5";
       cursor_trail_start_threshold = 0;
       confirm_os_window_close = 0;
+      clipboard_control = "write-clipboard write-primary read-clipboard read-primary";
     };
 
     themeFile = "Catppuccin-Mocha";

--- a/system/home-manager/applications/kitty.nix
+++ b/system/home-manager/applications/kitty.nix
@@ -28,7 +28,7 @@ in
       cursor_trail_decay = "0 0.5";
       cursor_trail_start_threshold = 0;
       confirm_os_window_close = 0;
-      clipboard_control = "write-clipboard write-primary read-clipboard read-primary";
+      clipboard_control = "write-clipboard write-primary";
     };
 
     themeFile = "Catppuccin-Mocha";

--- a/system/home-manager/applications/kitty.nix
+++ b/system/home-manager/applications/kitty.nix
@@ -22,7 +22,6 @@ in
     };
 
     settings = {
-      "ctrl+c" = "copy_or_interrupt";
       cursor_blink_interval = 0;
       clear_all_shortcuts = "no";
       cursor_trail = 0;
@@ -37,6 +36,7 @@ in
     shellIntegration.enableFishIntegration = config.settings.shell == "fish";
 
     keybindings = {
+      "ctrl+c" = "copy_or_interrupt";
       "alt+s>n" = "goto_session ${neovim_session}";
       "alt+s>t" = "goto_session ${homelab_session}";
       "alt+s>e" = "goto_session ${nix_session}";


### PR DESCRIPTION
## Summary
- `ctrl+c = copy_or_interrupt` was declared under `programs.kitty.settings`, so home-manager wrote it to `kitty.conf` as a bare line, which kitty rejected: `Ignoring invalid config line: 'ctrl+c copy_or_interrupt'`.
- Moving it to `programs.kitty.keybindings` emits the correct `map ctrl+c copy_or_interrupt` directive.

## Test plan
- [ ] `nixos` rebuild succeeds
- [ ] Opening a new kitty window no longer prints the invalid-config-line warning
- [ ] `Ctrl+C` still copies on selection and interrupts otherwise