### PR TITLE
feat(firefox): add Drizzle Studio quick-access bookmark

### DIFF
--- a/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/quick-access.nix
+++ b/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/quick-access.nix
@@ -43,6 +43,14 @@
             ];
             url = "https://www.typescriptlang.org/play/";
           }
+          {
+            name = "Drizzle Studio";
+            tags = [
+              "local"
+              "database"
+            ];
+            url = "https://local.drizzle.studio/?host=127.0.0.1&port=3001";
+          }
         ];
       }
       {


### PR DESCRIPTION
## Summary
- Add a Drizzle Studio bookmark to the Firefox quick-access folder pointing at the local instance (127.0.0.1:3001).

## Test plan
- [ ] Rebuild home-manager and verify the bookmark appears under quick-access