### PR TITLE
fix(firefox): correct Jellyfin bookmark port to 8096

### DIFF
--- a/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/self-hosted.nix
+++ b/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/self-hosted.nix
@@ -24,7 +24,7 @@
           {
             name = "Jellifin";
             tags = [ "self-hosted" ];
-            url = "http://192.168.1.110:8000/";
+            url = "http://192.168.1.110:8096";
           }
           {
             name = "qBittorrent";


### PR DESCRIPTION
## Summary
- Fix Jellyfin self-hosted bookmark URL from `http://192.168.1.110:8000/` to `http://192.168.1.110:8096`

## Test plan
- [ ] Rebuild and confirm bookmark opens Jellyfin

🤖 Generated with [Claude Code](https://claude.com/claude-code)