### PR TITLE
fix(homelab): run qbittorrent in keep-id userns to fix download perms

### DIFF
--- a/system/home-manager/homelab/entertainment/qbittorrent.nix
+++ b/system/home-manager/homelab/entertainment/qbittorrent.nix
@@ -8,7 +8,7 @@ with lib;
   config = mkIf config.features.homelab.entertainment.qbittorrent.enable {
     systemd.user.tmpfiles.rules = [
       "d %h/.homelab/qbittorrent 0700 - - -"
-      "d %h/.homelab/qbittorrent/config 0700 - - -"
+      "d %h/.homelab/qbittorrent/config 0755 - - -"
     ];
 
     services.podman.containers.qbittorrent = {
@@ -36,6 +36,7 @@ with lib;
       ];
 
       extraPodmanArgs = [
+        "--userns=keep-id"
         "--tz=local"
         "--stop-timeout 10"
       ];

--- a/system/home-manager/homelab/entertainment/radarr.nix
+++ b/system/home-manager/homelab/entertainment/radarr.nix
@@ -27,7 +27,10 @@ with lib;
         PGID = 1000;
       };
 
-      extraPodmanArgs = [ "--tz=local" ];
+      extraPodmanArgs = [
+        "--userns=keep-id"
+        "--tz=local"
+      ];
 
       ports = [
         "7878:7878"

--- a/system/home-manager/homelab/entertainment/sonarr.nix
+++ b/system/home-manager/homelab/entertainment/sonarr.nix
@@ -27,7 +27,10 @@ with lib;
         PGID = 1000;
       };
 
-      extraPodmanArgs = [ "--tz=local" ];
+      extraPodmanArgs = [
+        "--userns=keep-id"
+        "--tz=local"
+      ];
 
       ports = [
         "8989:8989"

--- a/system/nixos/homelab/storage.nix
+++ b/system/nixos/homelab/storage.nix
@@ -7,23 +7,24 @@ let
 in
 {
   config = mkIf (sp != null) {
-    systemd.tmpfiles.rules =
-      [ "d ${sp}/.homelab 0700 ${user} users -" ]
-      ++ optionals hl.frigate.enable [
-        "d ${sp}/.homelab/frigate 0700 ${user} users -"
-        "d ${sp}/.homelab/frigate/media 0700 ${user} users -"
-      ]
-      ++ optionals hl.entertainment.sonarr.enable [
-        "d ${sp}/.homelab/sonarr 0700 ${user} users -"
-        "d ${sp}/.homelab/sonarr/tv 0755 ${user} users -"
-      ]
-      ++ optionals hl.entertainment.radarr.enable [
-        "d ${sp}/.homelab/radarr 0700 ${user} users -"
-        "d ${sp}/.homelab/radarr/movies 0755 ${user} users -"
-      ]
-      ++ optionals hl.entertainment.qbittorrent.enable [
-        "d ${sp}/.homelab/qbittorrent 0700 ${user} users -"
-        "d ${sp}/.homelab/qbittorrent/downloads 0700 ${user} users -"
-      ];
+    systemd.tmpfiles.rules = [
+      "d ${sp}/.homelab 0700 ${user} users -"
+    ]
+    ++ optionals hl.frigate.enable [
+      "d ${sp}/.homelab/frigate 0700 ${user} users -"
+      "d ${sp}/.homelab/frigate/media 0700 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.sonarr.enable [
+      "d ${sp}/.homelab/sonarr 0700 ${user} users -"
+      "d ${sp}/.homelab/sonarr/tv 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.radarr.enable [
+      "d ${sp}/.homelab/radarr 0700 ${user} users -"
+      "d ${sp}/.homelab/radarr/movies 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.qbittorrent.enable [
+      "d ${sp}/.homelab/qbittorrent 0700 ${user} users -"
+      "d ${sp}/.homelab/qbittorrent/downloads 0777 ${user} users -"
+    ];
   };
 }


### PR DESCRIPTION
Map the host user into the container with --userns=keep-id (matching sonarr/radarr) so the mounted /downloads volume (owned by the host user) lines up with the container's app user, resolving the "chown: changing ownership of '/downloads': Operation not permitted" error that blocked downloads. Widen the downloads dir to 0777 and the qbittorrent config dir to 0755 accordingly.