### PR TITLE
chore(home-manager): misc config fixes across six modules

### DIFF
--- a/system/home-manager/applications/firefox/default.nix
+++ b/system/home-manager/applications/firefox/default.nix
@@ -29,7 +29,6 @@
 
   programs.firefox = {
     enable = config.features.web.enable;
-    configPath = ".mozilla/firefox";
 
     # ---- POLICIES ----
     # Check about:policies#documentation for options.

--- a/system/home-manager/applications/firefox/default.nix
+++ b/system/home-manager/applications/firefox/default.nix
@@ -29,6 +29,7 @@
 
   programs.firefox = {
     enable = config.features.web.enable;
+    configPath = ".mozilla/firefox";
 
     # ---- POLICIES ----
     # Check about:policies#documentation for options.

--- a/system/home-manager/applications/neovim.nix
+++ b/system/home-manager/applications/neovim.nix
@@ -9,6 +9,8 @@
     defaultEditor = true;
     viAlias = true;
     vimAlias = true;
+    withRuby = false;
+    withPython3 = false;
     extraPackages = with pkgs; [
       nodejs_24
       python3

--- a/system/home-manager/applications/styles.nix
+++ b/system/home-manager/applications/styles.nix
@@ -10,6 +10,8 @@
       package = pkgs.kdePackages.breeze-gtk;
     };
 
+    gtk4.theme = config.gtk.theme;
+
     cursorTheme = {
       inherit (config.settings.cursor) name package size;
     };

--- a/system/home-manager/applications/xdg.nix
+++ b/system/home-manager/applications/xdg.nix
@@ -10,6 +10,7 @@
     userDirs = {
       enable = true;
       createDirectories = false;
+      setSessionVariables = true;
     };
     mime.enable = true;
     portal.enable = lib.mkForce (config.features.desktop.xdg.enable);

--- a/system/home-manager/packages/dev/ai/opencode.nix
+++ b/system/home-manager/packages/dev/ai/opencode.nix
@@ -48,13 +48,15 @@ in
             "secrets*" = "deny";
           };
         };
+      };
+      tui = {
         theme = "catppuccin";
         keybinds = {
           messages_half_page_up = "ctrl+u";
           messages_half_page_down = "ctrl+d";
         };
       };
-      rules = common.rules;
+      context = common.rules;
     };
   };
 }

--- a/system/home-manager/packages/utility.nix
+++ b/system/home-manager/packages/utility.nix
@@ -23,8 +23,8 @@
     pass
 
     # file managers
-    xfce.thunar
-    xfce.tumbler
+    thunar
+    tumbler
     vifm
 
     # audio controls

--- a/system/home-manager/profile/desktop/ssh.nix
+++ b/system/home-manager/profile/desktop/ssh.nix
@@ -3,24 +3,24 @@
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
-    matchBlocks = {
+    settings = {
       "192.168.1.110" = {
-        user = "s1n7ax";
-        hostname = "192.168.1.110";
-        identityFile = "~/.ssh/home_server";
+        User = "s1n7ax";
+        HostName = "192.168.1.110";
+        IdentityFile = "~/.ssh/home_server";
       };
 
       "64.225.84.64" = {
-        user = "root";
-        hostname = "64.225.84.64";
-        identityFile = "~/.ssh/digitalocean";
+        User = "root";
+        HostName = "64.225.84.64";
+        IdentityFile = "~/.ssh/digitalocean";
       };
 
       "dev" = {
-        user = "s1n7ax";
-        hostname = "localhost";
-        port = 2222;
-        identityFile = "~/.ssh/id_ed25519";
+        User = "s1n7ax";
+        HostName = "localhost";
+        Port = 2222;
+        IdentityFile = "~/.ssh/id_ed25519";
       };
     };
   };


### PR DESCRIPTION
Closes #46

- Fix package refs `xfce.thunar/tumbler` → `thunar/tumbler` for nixpkgs 26.05
- Explicitly disable `withRuby`/`withPython3` in neovim, add `configPath` to firefox, propagate gtk4 theme, enable xdg session vars
- Restructure opencode config: nest `theme`/`keybinds` under `tui` key, rename `rules` → `context`
- Migrate `programs.ssh.matchBlocks` → `programs.ssh.settings` with PascalCase SSH directives (deprecated in HM 26.05)