### PR TITLE
feat(server): mount RAID enclosure at /storage-hdd resiliently

### DIFF
--- a/doc/adr/0001-storage-hdd-secondary-arr-storage.md
+++ b/doc/adr/0001-storage-hdd-secondary-arr-storage.md
@@ -1,0 +1,79 @@
+# 1. Use /storage-hdd as secondary ARR media storage
+
+- Status: Accepted
+- Date: 2026-06-16
+- Related: PR #48 (resilient `/storage-hdd` mount), PR #50 (this change), issue #49
+
+## Context
+
+The server has two data drives:
+
+- `/storage` — internal SSD, the primary data drive for the homelab ARR stack.
+- `/storage-hdd` — external RAID enclosure HDD, added in PR #48.
+
+The enclosure is unreliable: it occasionally powers itself off and does not come
+back on its own, and its ext4 filesystem periodically needs an fsck after an
+unclean power loss. PR #48 therefore mounted it with completely non-blocking
+options (`nofail`, `x-systemd.automount`, `device-timeout=1min`,
+`idle-timeout=0`) so a bad enclosure never fails the server's boot nor wedges any
+service. At that point `/storage-hdd` was only mounted and made available —
+nothing consumed it.
+
+We want the extra capacity of the HDD for the ARR stack (a second root folder /
+save path) without giving up the resilience PR #48 bought.
+
+## Decision
+
+Wire `/storage-hdd` into the ARR stack as a *secondary* media drive, alongside
+the SSD which remains primary:
+
+- A `settings.storageHddPath` option (mirrors `settings.storagePath`), set to
+  `/storage-hdd` on the server profile and `null` everywhere else.
+- The same `.homelab` directory structure used on `/storage`
+  (`sonarr/tv`, `radarr/movies`, `qbittorrent/downloads`) is replicated onto
+  `/storage-hdd`.
+- The ARR containers mount the HDD dirs as additional volumes, gated on
+  `storageHddPath != null`:
+  - sonarr → `/tv-hdd`, `/downloads-hdd`
+  - radarr → `/movies-hdd`, `/downloads-hdd`
+  - qbittorrent → `/downloads-hdd`
+  - jellyfin → `/movies-hdd`, `/tv-hdd`
+
+Keeping each drive's download and library dirs on the same filesystem preserves
+hardlink / atomic-move support for content destined to that drive.
+
+## Consequences
+
+Positive:
+
+- The ARR apps can use both drives as root folders; the HDD absorbs overflow the
+  SSD cannot hold.
+- Hosts without a second drive are unaffected (`storageHddPath` defaults to
+  `null`, so no HDD volumes or directories are created).
+- The SSD stays the default, so day-to-day behaviour is unchanged when the
+  enclosure is healthy.
+
+Negative — accepted trade-offs against PR #48's resilience:
+
+- **Entertainment containers couple to the enclosure.** Because the ARR
+  containers now bind-mount `/storage-hdd` subdirs, those containers fail to
+  start while the enclosure is powered off (podman cannot resolve the automount
+  source). This is contained to the entertainment stack — the services that
+  actually need the drive — while the rest of the system stays resilient.
+- **Boot can wait on the enclosure.** The `systemd-tmpfiles-setup` rules that
+  create the HDD directories run at boot and touch `/storage-hdd`, triggering the
+  automount. With the enclosure off, that access blocks up to the
+  `device-timeout` (1 min) before failing. `nofail` keeps it non-fatal, so it is
+  a boot *delay* in the failure case, not a boot failure.
+
+## Revisiting
+
+This is intentionally cheap to back out. If the enclosure fails often enough that
+the coupling above becomes annoying, remove the secondary storage:
+
+- Clear `settings.storageHddPath` on the server profile (set it back to `null`).
+  That alone drops every HDD container volume and the HDD `tmpfiles` rules, since
+  they are all gated on `storageHddPath != null`. The ARR apps fall back to the
+  SSD-only `/storage` layout and stop waiting on the enclosure.
+- Optionally also drop the `/storage-hdd` `fileSystems` entry from PR #48 if the
+  enclosure is retired entirely.

--- a/profile/server/configuration.nix
+++ b/profile/server/configuration.nix
@@ -2,6 +2,7 @@
   imports = [
     ../common/configuration.nix
     ./hardware-configuration.nix
+    ./storage-hdd.nix
     ./gpg.nix
     ./options.nix
     ../../system/nixos/profile/server

--- a/profile/server/configuration.nix
+++ b/profile/server/configuration.nix
@@ -2,7 +2,7 @@
   imports = [
     ../common/configuration.nix
     ./hardware-configuration.nix
-    ./storage-hdd.nix
+    ./storage.nix
     ./gpg.nix
     ./options.nix
     ../../system/nixos/profile/server

--- a/profile/server/hardware-configuration.nix
+++ b/profile/server/hardware-configuration.nix
@@ -49,6 +49,9 @@
     ];
   };
 
+  # The external RAID enclosure HDD is a *second* drive mounted at /storage-hdd
+  # with resilient, non-blocking options; see ./storage-hdd.nix.
+
   swapDevices = [
     { device = "/dev/disk/by-uuid/3d30ed3c-9547-4c4c-ae81-87d95b8861f6"; }
   ];

--- a/profile/server/hardware-configuration.nix
+++ b/profile/server/hardware-configuration.nix
@@ -40,17 +40,7 @@
     ];
   };
 
-  fileSystems."/storage" = {
-    device = "/dev/disk/by-uuid/a207886d-bcc6-4e13-a164-19550e340889";
-    fsType = "ext4";
-    options = [
-      "defaults"
-      "nofail"
-    ];
-  };
-
-  # The external RAID enclosure HDD is a *second* drive mounted at /storage-hdd
-  # with resilient, non-blocking options; see ./storage-hdd.nix.
+  # Disk mounts (/storage, /storage-hdd) live in ./storage.nix.
 
   swapDevices = [
     { device = "/dev/disk/by-uuid/3d30ed3c-9547-4c4c-ae81-87d95b8861f6"; }

--- a/profile/server/options.nix
+++ b/profile/server/options.nix
@@ -2,6 +2,7 @@
 {
   settings = {
     storagePath = "/storage";
+    storageHddPath = "/storage-hdd";
   };
 
   features = {

--- a/profile/server/storage-hdd.nix
+++ b/profile/server/storage-hdd.nix
@@ -1,0 +1,49 @@
+# /storage-hdd — the external RAID enclosure HDD, mounted as a second drive
+# alongside the internal /storage SSD.
+#
+# The enclosure is unreliable: it occasionally powers itself off (and does not
+# come back on its own), and its ext4 filesystem periodically needs an fsck after
+# an unclean loss of power. It is mounted with completely non-blocking options so
+# a bad enclosure never fails the server's boot nor wedges any service.
+#
+# The *arr stack still lives on the /storage SSD; for now this drive is only
+# mounted and made available. If something is later pointed at /storage-hdd, the
+# autofs behaviour below also gives it correct mount ordering for free.
+#
+#   nofail                        Boot never fails because of this mount.
+#
+#   x-systemd.automount + noauto  Mount lazily on first access instead of at boot,
+#                                 so boot proceeds immediately and nothing waits on
+#                                 the enclosure spinning up. The first access to
+#                                 /storage-hdd transparently blocks until the real
+#                                 fs is mounted, so a consumer can never write into
+#                                 an empty /storage-hdd on the root disk and then be
+#                                 shadowed when the drive mounts later.
+#
+#   x-systemd.device-timeout=1min How long to wait for the slow/flaky enclosure to
+#                                 present its device node before giving up. If the
+#                                 enclosure is switched off, an access fails after a
+#                                 minute instead of hanging forever.
+#
+#   x-systemd.idle-timeout=0      Never auto-unmount while idle (0 = disabled), so a
+#                                 long-lived consumer's bind mount can't go stale.
+#
+# fsck: systemd-fsck@.service ships with TimeoutSec=infinity, so a legitimate
+# repair is allowed to run to completion — this is the "wait for the fix to take
+# place" behaviour. e2fsck runs in the default preen mode; if the filesystem is too
+# damaged to repair automatically it bails, and thanks to nofail the mount is simply
+# skipped rather than blocking the boot.
+{ ... }:
+{
+  fileSystems."/storage-hdd" = {
+    device = "/dev/disk/by-uuid/58670f4d-422d-4fbc-b179-78c0cb8d0e5b";
+    fsType = "ext4";
+    options = [
+      "nofail"
+      "noauto"
+      "x-systemd.automount"
+      "x-systemd.device-timeout=1min"
+      "x-systemd.idle-timeout=0"
+    ];
+  };
+}

--- a/profile/server/storage.nix
+++ b/profile/server/storage.nix
@@ -1,18 +1,22 @@
-# /storage-hdd — the external RAID enclosure HDD, mounted as a second drive
-# alongside the internal /storage SSD.
+# Local disk mounts for the server, kept here (rather than in the generated
+# hardware-configuration.nix) so the hand-tuned mount options live in a file
+# that nixos-generate-config won't overwrite.
+#
+#   /storage      internal SSD, the primary data drive (the *arr stack, etc.).
+#   /storage-hdd  external RAID enclosure HDD, a second drive.
 #
 # The enclosure is unreliable: it occasionally powers itself off (and does not
 # come back on its own), and its ext4 filesystem periodically needs an fsck after
 # an unclean loss of power. It is mounted with completely non-blocking options so
 # a bad enclosure never fails the server's boot nor wedges any service.
 #
-# The *arr stack still lives on the /storage SSD; for now this drive is only
+# The *arr stack still lives on the /storage SSD; for now /storage-hdd is only
 # mounted and made available. If something is later pointed at /storage-hdd, the
 # autofs behaviour below also gives it correct mount ordering for free.
 #
 #   nofail                        Boot never fails because of this mount.
 #
-#   x-systemd.automount + noauto  Mount lazily on first access instead of at boot,
+#   x-systemd.automount           Mount lazily on first access instead of at boot,
 #                                 so boot proceeds immediately and nothing waits on
 #                                 the enclosure spinning up. The first access to
 #                                 /storage-hdd transparently blocks until the real
@@ -35,12 +39,20 @@
 # skipped rather than blocking the boot.
 { ... }:
 {
+  fileSystems."/storage" = {
+    device = "/dev/disk/by-uuid/a207886d-bcc6-4e13-a164-19550e340889";
+    fsType = "ext4";
+    options = [
+      "defaults"
+      "nofail"
+    ];
+  };
+
   fileSystems."/storage-hdd" = {
     device = "/dev/disk/by-uuid/58670f4d-422d-4fbc-b179-78c0cb8d0e5b";
     fsType = "ext4";
     options = [
       "nofail"
-      "noauto"
       "x-systemd.automount"
       "x-systemd.device-timeout=1min"
       "x-systemd.idle-timeout=0"

--- a/system/home-manager/homelab/entertainment/jellyfin.nix
+++ b/system/home-manager/homelab/entertainment/jellyfin.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/jellyfin";
   movie_path = "${config.settings.storagePath}/.homelab/radarr/movies";
   tv_path = "${config.settings.storagePath}/.homelab/sonarr/tv";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${movie_path}:/movies:z"
         "${tv_path}:/tv:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/radarr/movies:/movies-hdd:z"
+        "${hdd}/.homelab/sonarr/tv:/tv-hdd:z"
       ];
 
       environment = {

--- a/system/home-manager/homelab/entertainment/qbittorrent.nix
+++ b/system/home-manager/homelab/entertainment/qbittorrent.nix
@@ -2,6 +2,7 @@
 let
   data_path = "${config.home.homeDirectory}/.homelab/qbittorrent";
   storage_path = "${config.settings.storagePath}/.homelab/qbittorrent";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -27,6 +28,9 @@ with lib;
       volumes = [
         "${data_path}/config:/config"
         "${storage_path}/downloads:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       ports = [

--- a/system/home-manager/homelab/entertainment/radarr.nix
+++ b/system/home-manager/homelab/entertainment/radarr.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/radarr";
   storage_path = "${config.settings.storagePath}/.homelab/radarr";
   download_path = "${config.settings.storagePath}/.homelab/qbittorrent/downloads";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${storage_path}/movies:/movies:z"
         "${download_path}:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/radarr/movies:/movies-hdd:z"
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       environment = {

--- a/system/home-manager/homelab/entertainment/sonarr.nix
+++ b/system/home-manager/homelab/entertainment/sonarr.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/sonarr";
   storage_path = "${config.settings.storagePath}/.homelab/sonarr";
   download_path = "${config.settings.storagePath}/.homelab/qbittorrent/downloads";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${storage_path}/tv:/tv:z"
         "${download_path}:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/sonarr/tv:/tv-hdd:z"
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       environment = {

--- a/system/nixos/homelab/storage.nix
+++ b/system/nixos/homelab/storage.nix
@@ -2,8 +2,26 @@
 with lib;
 let
   sp = config.settings.storagePath;
+  hdd = config.settings.storageHddPath;
   user = config.settings.username;
   hl = config.features.homelab;
+
+  # ARR-stack media directories, replicated on each storage backend (the primary
+  # /storage SSD and the secondary /storage-hdd RAID enclosure) so the apps can
+  # use both drives as root folders / save paths.
+  arrRules = base:
+    optionals hl.entertainment.sonarr.enable [
+      "d ${base}/.homelab/sonarr 0700 ${user} users -"
+      "d ${base}/.homelab/sonarr/tv 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.radarr.enable [
+      "d ${base}/.homelab/radarr 0700 ${user} users -"
+      "d ${base}/.homelab/radarr/movies 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.qbittorrent.enable [
+      "d ${base}/.homelab/qbittorrent 0700 ${user} users -"
+      "d ${base}/.homelab/qbittorrent/downloads 0777 ${user} users -"
+    ];
 in
 {
   config = mkIf (sp != null) {
@@ -14,17 +32,9 @@ in
       "d ${sp}/.homelab/frigate 0700 ${user} users -"
       "d ${sp}/.homelab/frigate/media 0700 ${user} users -"
     ]
-    ++ optionals hl.entertainment.sonarr.enable [
-      "d ${sp}/.homelab/sonarr 0700 ${user} users -"
-      "d ${sp}/.homelab/sonarr/tv 0755 ${user} users -"
-    ]
-    ++ optionals hl.entertainment.radarr.enable [
-      "d ${sp}/.homelab/radarr 0700 ${user} users -"
-      "d ${sp}/.homelab/radarr/movies 0755 ${user} users -"
-    ]
-    ++ optionals hl.entertainment.qbittorrent.enable [
-      "d ${sp}/.homelab/qbittorrent 0700 ${user} users -"
-      "d ${sp}/.homelab/qbittorrent/downloads 0777 ${user} users -"
-    ];
+    ++ arrRules sp
+    ++ optionals (hdd != null) (
+      [ "d ${hdd}/.homelab 0700 ${user} users -" ] ++ arrRules hdd
+    );
   };
 }

--- a/system/options.nix
+++ b/system/options.nix
@@ -76,6 +76,11 @@ with lib;
       default = null;
       description = "Path to the large storage mount point (e.g., /storage for HDD). Set to null if not using external storage.";
     };
+    storageHddPath = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Path to a secondary storage mount point (e.g., /storage-hdd RAID enclosure) used as additional ARR-stack media storage. Set to null if not using a second drive.";
+    };
     network = {
       backend = mkOption {
         type = types.enum [


### PR DESCRIPTION
## What

Mounts the external **RAID enclosure** (UUID `58670f4d…`) as a *second* drive at **`/storage-hdd`**, with fully non-blocking options so the flaky enclosure can never fail the server's boot or wedge any service. The internal **`/storage` SSD** (UUID `a207886d…`) is reliable and stays exactly as it was.

- New documented **`profile/server/storage-hdd.nix`** defines `/storage-hdd`. The generated `hardware-configuration.nix` keeps the unchanged `/storage` SSD entry (a comment points at the new file for the enclosure).
- **`nofail` + `x-systemd.automount` (`noauto`)** — boot never waits on the enclosure spinning up; it mounts lazily on first access. autofs makes the first access to `/storage-hdd` block until the real fs is mounted, so a future consumer can't shadow-write an empty dir on the root disk and get masked when the drive mounts.
- **`x-systemd.device-timeout=1min`** bounds the wait for the slow/flaky enclosure to appear (off → access fails after a minute instead of hanging). **`x-systemd.idle-timeout=0`** never auto-unmounts, so long-lived bind mounts don't go stale.
- **fsck**: `systemd-fsck@.service` ships with `TimeoutSec=infinity`, so a real repair runs to completion. The premature "timeout before the fix finished" previously seen at boot was the *device* wait, not fsck. Generated fstab passno is `2`, so fsck still runs.

The **\*arr stack stays on the `/storage` SSD for now** — wiring it to use `/storage-hdd` is a deliberate later/separate change.

## Requirements mapping

| Requirement | How |
|---|---|
| Don't fail boot if the enclosure fails | `nofail` + `automount` — boot never waits/fails |
| Don't block/freeze other services | `automount` isolates any wait to whoever touches `/storage-hdd` |
| Available before a consumer uses it | autofs blocks first access until the fs is mounted |
| Wait for fsck rather than skip early | `systemd-fsck@` has `TimeoutSec=infinity`; only the bounded *device* wait can give up |
| Two drives | `/storage` (SSD) + `/storage-hdd` (enclosure) both mounted |

## Generated fstab

```
/dev/disk/by-uuid/a207886d-… /storage     ext4 defaults,nofail 0 2
/dev/disk/by-uuid/58670f4d-… /storage-hdd ext4 nofail,noauto,x-systemd.automount,x-systemd.device-timeout=1min,x-systemd.idle-timeout=0 0 2
```

## Notes / assumptions
- Assumes the enclosure fs is **ext4** (matches its prior entry + e2fsck history). If it's now a different fs, update `fsType` in `profile/server/storage-hdd.nix`.
- Validated with a full `nix eval` of `nixosConfigurations.server` (toplevel derivation builds; both fstab lines confirmed). **Not** deployed — apply on the server with `nixos-rebuild switch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)