### PR TITLE
feat(homelab): wire /storage-hdd into ARR stack as secondary media storage

### DIFF
--- a/doc/adr/0001-storage-hdd-secondary-arr-storage.md
+++ b/doc/adr/0001-storage-hdd-secondary-arr-storage.md
@@ -1,0 +1,79 @@
+# 1. Use /storage-hdd as secondary ARR media storage
+
+- Status: Accepted
+- Date: 2026-06-16
+- Related: PR #48 (resilient `/storage-hdd` mount), PR #50 (this change), issue #49
+
+## Context
+
+The server has two data drives:
+
+- `/storage` — internal SSD, the primary data drive for the homelab ARR stack.
+- `/storage-hdd` — external RAID enclosure HDD, added in PR #48.
+
+The enclosure is unreliable: it occasionally powers itself off and does not come
+back on its own, and its ext4 filesystem periodically needs an fsck after an
+unclean power loss. PR #48 therefore mounted it with completely non-blocking
+options (`nofail`, `x-systemd.automount`, `device-timeout=1min`,
+`idle-timeout=0`) so a bad enclosure never fails the server's boot nor wedges any
+service. At that point `/storage-hdd` was only mounted and made available —
+nothing consumed it.
+
+We want the extra capacity of the HDD for the ARR stack (a second root folder /
+save path) without giving up the resilience PR #48 bought.
+
+## Decision
+
+Wire `/storage-hdd` into the ARR stack as a *secondary* media drive, alongside
+the SSD which remains primary:
+
+- A `settings.storageHddPath` option (mirrors `settings.storagePath`), set to
+  `/storage-hdd` on the server profile and `null` everywhere else.
+- The same `.homelab` directory structure used on `/storage`
+  (`sonarr/tv`, `radarr/movies`, `qbittorrent/downloads`) is replicated onto
+  `/storage-hdd`.
+- The ARR containers mount the HDD dirs as additional volumes, gated on
+  `storageHddPath != null`:
+  - sonarr → `/tv-hdd`, `/downloads-hdd`
+  - radarr → `/movies-hdd`, `/downloads-hdd`
+  - qbittorrent → `/downloads-hdd`
+  - jellyfin → `/movies-hdd`, `/tv-hdd`
+
+Keeping each drive's download and library dirs on the same filesystem preserves
+hardlink / atomic-move support for content destined to that drive.
+
+## Consequences
+
+Positive:
+
+- The ARR apps can use both drives as root folders; the HDD absorbs overflow the
+  SSD cannot hold.
+- Hosts without a second drive are unaffected (`storageHddPath` defaults to
+  `null`, so no HDD volumes or directories are created).
+- The SSD stays the default, so day-to-day behaviour is unchanged when the
+  enclosure is healthy.
+
+Negative — accepted trade-offs against PR #48's resilience:
+
+- **Entertainment containers couple to the enclosure.** Because the ARR
+  containers now bind-mount `/storage-hdd` subdirs, those containers fail to
+  start while the enclosure is powered off (podman cannot resolve the automount
+  source). This is contained to the entertainment stack — the services that
+  actually need the drive — while the rest of the system stays resilient.
+- **Boot can wait on the enclosure.** The `systemd-tmpfiles-setup` rules that
+  create the HDD directories run at boot and touch `/storage-hdd`, triggering the
+  automount. With the enclosure off, that access blocks up to the
+  `device-timeout` (1 min) before failing. `nofail` keeps it non-fatal, so it is
+  a boot *delay* in the failure case, not a boot failure.
+
+## Revisiting
+
+This is intentionally cheap to back out. If the enclosure fails often enough that
+the coupling above becomes annoying, remove the secondary storage:
+
+- Clear `settings.storageHddPath` on the server profile (set it back to `null`).
+  That alone drops every HDD container volume and the HDD `tmpfiles` rules, since
+  they are all gated on `storageHddPath != null`. The ARR apps fall back to the
+  SSD-only `/storage` layout and stop waiting on the enclosure.
+- Optionally also drop the `/storage-hdd` `fileSystems` entry from PR #48 if the
+  enclosure is retired entirely.

--- a/profile/server/options.nix
+++ b/profile/server/options.nix
@@ -2,6 +2,7 @@
 {
   settings = {
     storagePath = "/storage";
+    storageHddPath = "/storage-hdd";
   };
 
   features = {

--- a/system/home-manager/homelab/entertainment/jellyfin.nix
+++ b/system/home-manager/homelab/entertainment/jellyfin.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/jellyfin";
   movie_path = "${config.settings.storagePath}/.homelab/radarr/movies";
   tv_path = "${config.settings.storagePath}/.homelab/sonarr/tv";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${movie_path}:/movies:z"
         "${tv_path}:/tv:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/radarr/movies:/movies-hdd:z"
+        "${hdd}/.homelab/sonarr/tv:/tv-hdd:z"
       ];
 
       environment = {

--- a/system/home-manager/homelab/entertainment/qbittorrent.nix
+++ b/system/home-manager/homelab/entertainment/qbittorrent.nix
@@ -2,6 +2,7 @@
 let
   data_path = "${config.home.homeDirectory}/.homelab/qbittorrent";
   storage_path = "${config.settings.storagePath}/.homelab/qbittorrent";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -27,6 +28,9 @@ with lib;
       volumes = [
         "${data_path}/config:/config"
         "${storage_path}/downloads:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       ports = [

--- a/system/home-manager/homelab/entertainment/radarr.nix
+++ b/system/home-manager/homelab/entertainment/radarr.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/radarr";
   storage_path = "${config.settings.storagePath}/.homelab/radarr";
   download_path = "${config.settings.storagePath}/.homelab/qbittorrent/downloads";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${storage_path}/movies:/movies:z"
         "${download_path}:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/radarr/movies:/movies-hdd:z"
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       environment = {

--- a/system/home-manager/homelab/entertainment/sonarr.nix
+++ b/system/home-manager/homelab/entertainment/sonarr.nix
@@ -3,6 +3,7 @@ let
   data_path = "${config.home.homeDirectory}/.homelab/sonarr";
   storage_path = "${config.settings.storagePath}/.homelab/sonarr";
   download_path = "${config.settings.storagePath}/.homelab/qbittorrent/downloads";
+  hdd = config.settings.storageHddPath;
 in
 with lib;
 {
@@ -20,6 +21,10 @@ with lib;
         "${data_path}/config:/config:Z"
         "${storage_path}/tv:/tv:z"
         "${download_path}:/downloads:z"
+      ]
+      ++ optionals (hdd != null) [
+        "${hdd}/.homelab/sonarr/tv:/tv-hdd:z"
+        "${hdd}/.homelab/qbittorrent/downloads:/downloads-hdd:z"
       ];
 
       environment = {

--- a/system/nixos/homelab/storage.nix
+++ b/system/nixos/homelab/storage.nix
@@ -2,8 +2,26 @@
 with lib;
 let
   sp = config.settings.storagePath;
+  hdd = config.settings.storageHddPath;
   user = config.settings.username;
   hl = config.features.homelab;
+
+  # ARR-stack media directories, replicated on each storage backend (the primary
+  # /storage SSD and the secondary /storage-hdd RAID enclosure) so the apps can
+  # use both drives as root folders / save paths.
+  arrRules = base:
+    optionals hl.entertainment.sonarr.enable [
+      "d ${base}/.homelab/sonarr 0700 ${user} users -"
+      "d ${base}/.homelab/sonarr/tv 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.radarr.enable [
+      "d ${base}/.homelab/radarr 0700 ${user} users -"
+      "d ${base}/.homelab/radarr/movies 0755 ${user} users -"
+    ]
+    ++ optionals hl.entertainment.qbittorrent.enable [
+      "d ${base}/.homelab/qbittorrent 0700 ${user} users -"
+      "d ${base}/.homelab/qbittorrent/downloads 0777 ${user} users -"
+    ];
 in
 {
   config = mkIf (sp != null) {
@@ -14,17 +32,9 @@ in
       "d ${sp}/.homelab/frigate 0700 ${user} users -"
       "d ${sp}/.homelab/frigate/media 0700 ${user} users -"
     ]
-    ++ optionals hl.entertainment.sonarr.enable [
-      "d ${sp}/.homelab/sonarr 0700 ${user} users -"
-      "d ${sp}/.homelab/sonarr/tv 0755 ${user} users -"
-    ]
-    ++ optionals hl.entertainment.radarr.enable [
-      "d ${sp}/.homelab/radarr 0700 ${user} users -"
-      "d ${sp}/.homelab/radarr/movies 0755 ${user} users -"
-    ]
-    ++ optionals hl.entertainment.qbittorrent.enable [
-      "d ${sp}/.homelab/qbittorrent 0700 ${user} users -"
-      "d ${sp}/.homelab/qbittorrent/downloads 0777 ${user} users -"
-    ];
+    ++ arrRules sp
+    ++ optionals (hdd != null) (
+      [ "d ${hdd}/.homelab 0700 ${user} users -" ] ++ arrRules hdd
+    );
   };
 }

--- a/system/options.nix
+++ b/system/options.nix
@@ -76,6 +76,11 @@ with lib;
       default = null;
       description = "Path to the large storage mount point (e.g., /storage for HDD). Set to null if not using external storage.";
     };
+    storageHddPath = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Path to a secondary storage mount point (e.g., /storage-hdd RAID enclosure) used as additional ARR-stack media storage. Set to null if not using a second drive.";
+    };
     network = {
       backend = mkOption {
         type = types.enum [


### PR DESCRIPTION
## What

Consumes the `/storage-hdd` mount added in #48 by wiring it into the homelab ARR stack as a secondary media drive.

- Adds `settings.storageHddPath` option (mirrors `storagePath`), set to `/storage-hdd` on the server profile.
- Replicates the `.homelab` ARR directory structure (`sonarr/tv`, `radarr/movies`, `qbittorrent/downloads`) onto `/storage-hdd` via `storage.nix` (refactored into a reusable `arrRules` helper applied to both backends).
- Mounts the HDD media dirs into the ARR containers as additional volumes:
  - **sonarr** → `/tv-hdd`, `/downloads-hdd`
  - **radarr** → `/movies-hdd`, `/downloads-hdd`
  - **qbittorrent** → `/downloads-hdd`
  - **jellyfin** → `/movies-hdd`, `/tv-hdd`

HDD volumes are gated on `storageHddPath != null`, so hosts without a second drive are unaffected. Keeping the HDD download + library dirs on the same filesystem preserves hardlink/atomic-move support for HDD-bound content.

## Notes

- **Stacked on #48** — base is `fix/storage-hdd-resilient-automount`. Retarget to `main` once #48 merges.
- **Resilience tradeoff:** because the ARR containers now bind-mount `/storage-hdd` subdirs, those containers will fail to start while the enclosure is powered off (podman can't resolve the automount source). The rest of the system stays resilient per #48 — only the entertainment stack, which actually needs the drive, is coupled to it.

## Testing

`nixos-rebuild build .#server` evaluates the full system derivation successfully (realisation failed only on a sandbox OOM/substituter issue, unrelated to config). Targeted `nix eval` confirms the produced tmpfiles rules and container volumes — proof posted below.

Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)