### PR TITLE
feat(ai): add mcp-nixos MCP server via nixpkgs package

### DIFF
--- a/system/home-manager/packages/dev/ai/common.nix
+++ b/system/home-manager/packages/dev/ai/common.nix
@@ -1,6 +1,10 @@
 { ... }:
 {
   mcpServers = {
+    nixos = {
+      command = "mcp-nixos";
+      args = [ ];
+    };
     svelte = {
       command = "npx";
       args = [

--- a/system/home-manager/packages/dev/ai/mcp.nix
+++ b/system/home-manager/packages/dev/ai/mcp.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -8,6 +9,9 @@ let
 in
 {
   config = lib.mkIf config.features.development.ai.enable {
+    # mcp-nixos binary backing the `nixos` MCP server (also used by Claude Code).
+    home.packages = [ pkgs.mcp-nixos ];
+
     programs.mcp = {
       enable = true;
       servers = common.mcpServers;


### PR DESCRIPTION
## Summary

- Install `pkgs.mcp-nixos` (nixpkgs stable, 2.4.3) on PATH via `mcp.nix` and register a `nixos` MCP server pointing at the binary in `common.nix` — replaces per-launch `nix run github:utensils/mcp-nixos`.
- Feeds opencode via `programs.mcp` → `~/.config/mcp/mcp.json`; Claude Code's local config points at the same `mcp-nixos` binary.

## Verification

- `nixosConfigurations.desktop` home-manager config evaluates; generated `mcp.json` includes `nixos → mcp-nixos`.
- `home.packages` contains `mcp-nixos`.
- `mcp-nixos` 2.4.3 binary completes an MCP `initialize` handshake (serverInfo `mcp-nixos` 2.4.3).

Closes #53