### PR TITLE
fix(hyprland): restore wallpaper — absolute path + match hyprpaper to compositor channel

### DIFF
--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -3,6 +3,7 @@
   lib,
   inputs,
   pkgs,
+  pkgs-unstable,
   ...
 }:
 let
@@ -21,6 +22,11 @@ in
 
   services.hyprpaper = {
     enable = true;
+    # Must come from the same nixpkgs channel as the Hyprland compositor
+    # (pkgs-unstable). A stable hyprpaper links a different libhyprwire /
+    # libhyprtoolkit than the unstable compositor and crashes with
+    # "Disconnected from pollfd id 0" (Backend.cpp:367).
+    package = pkgs-unstable.hyprpaper;
     settings = {
       splash = false;
       preload = [ "${config.home.homeDirectory}/.wallpaper/wallpaper" ];

--- a/system/home-manager/applications/hyprland.nix
+++ b/system/home-manager/applications/hyprland.nix
@@ -23,8 +23,8 @@ in
     enable = true;
     settings = {
       splash = false;
-      preload = [ "~/.wallpaper/wallpaper" ];
-      wallpaper = [ ",~/.wallpaper/wallpaper" ];
+      preload = [ "${config.home.homeDirectory}/.wallpaper/wallpaper" ];
+      wallpaper = [ ",${config.home.homeDirectory}/.wallpaper/wallpaper" ];
     };
   };
 


### PR DESCRIPTION
## Symptom

Hyprland wallpaper "stopped working" — blank background. hyprpaper was loading the image and then dying in a restart loop.

## Root causes (two, both fixed here)

1. **`~` not resolving in the hyprpaper config.** `preload=~/.wallpaper/wallpaper` never loaded, so the monitor got `Monitor DP-3 has no target: no wp will be created`. Fixed by rendering an absolute path via `config.home.homeDirectory`.

2. **Channel mismatch between hyprpaper and the compositor (the real killer).** Hyprland is pinned to `pkgs-unstable.hyprland`, but `services.hyprpaper` used the stable `pkgs.hyprpaper`. The two linked different builds of `libhyprwire`/`libhyprtoolkit`/`libaquamarine`, so hyprpaper crashed repeatedly with:
   ```
   ASSERTION FAILED! [core] Disconnected from pollfd id 0
   at: line 367 in Backend.cpp
   hyprpaper.service: Main process exited, code=dumped, status=6/ABRT
   ```
   Fixed by pinning `services.hyprpaper.package = pkgs-unstable.hyprpaper`.

## Verification

- Image confirmed a valid PNG (magic bytes `89 50 4e 47`), so format was never the issue.
- `hyprctl hyprpaper listactive` showed the wallpaper *was* loaded between crashes.
- Store-path check confirms the fix flips hyprpaper from the stable build to the unstable one that matches the compositor:
  - before: `…33ci94…-hyprpaper-0.8.4` (stable, what the host runs)
  - after:  `…i2yd553…-hyprpaper-0.8.4` (= `pkgs-unstable.hyprpaper`)

## Apply on host

```
sudo nixos-rebuild switch --flake .#desktop
```
Then **log out and back in** — the running compositor is the stale pre-rebuild binary; a full session restart brings compositor + hyprpaper up together from the same generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)