### PR TITLE
fix(homelab): wait for Home Assistant before starting Node-RED

### DIFF
--- a/system/home-manager/homelab/node-red.nix
+++ b/system/home-manager/homelab/node-red.nix
@@ -1,9 +1,25 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 with lib;
+let
+  # Node-RED's home-assistant-websocket nodes snapshot HA's entity registry on
+  # connect. If Node-RED starts while HA is still booting its integrations, that
+  # snapshot is incomplete. Block startup until HA's HTTP API answers (on its
+  # published host port), bounded so Node-RED always starts eventually — worst
+  # case is the pre-existing behaviour, never worse.
+  waitForHomeAssistant = pkgs.writeShellScript "wait-for-home-assistant" ''
+    end=$(( SECONDS + 300 ))
+    while [ "$SECONDS" -lt "$end" ]; do
+      ${pkgs.curl}/bin/curl -fsS -m 5 http://127.0.0.1:8124/ >/dev/null 2>&1 && exit 0
+      ${pkgs.coreutils}/bin/sleep 5
+    done
+    exit 0
+  '';
+in
 {
   config = mkIf config.features.homelab.node-red.enable {
     systemd.user.tmpfiles.rules = [
@@ -27,6 +43,17 @@ with lib;
         "${config.home.homeDirectory}/.homelab/node-red:/data:Z"
       ];
       autoStart = true;
+
+      # Wait for Home Assistant to be reachable before starting (only when HA is
+      # actually enabled). TimeoutStartSec must exceed the wait ceiling above, or
+      # systemd would kill the start as timed out while ExecStartPre polls.
+      extraConfig = mkIf config.features.homelab.home-assistant.enable {
+        Unit.After = [ "podman-home-assistant.service" ];
+        Service = {
+          ExecStartPre = "${waitForHomeAssistant}";
+          TimeoutStartSec = 360;
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
## Problem

Node-RED occasionally comes up with an **incomplete set of Home Assistant entities**. The `node-red-contrib-home-assistant-websocket` nodes snapshot HA's entity/device registry when they connect; if Node-RED's container starts before HA has finished booting its integrations, that snapshot is partial.

## Why plain ordering isn't enough

`After=podman-home-assistant.service` only waits for HA's **container to start**, not for HA to finish loading entities (a 30s–2min gap). Closing it needs a *readiness* gate, not just start ordering.

## Approach (and why this one)

I deliberately **did not** gate HA's own unit on a healthcheck (`Notify=healthy`): if the health command were even slightly wrong in the HA image — which I can't test from a non-homelab host — HA itself would fail to start. Trading a minor Node-RED annoyance for any risk to HA availability is a bad trade.

Instead the wait is **isolated to Node-RED**: an `ExecStartPre` polls HA's published HTTP port (`127.0.0.1:8124`) until it answers, **bounded to 5 minutes** so Node-RED always starts eventually. Worst case is exactly the pre-existing behaviour — never worse — and **HA's unit is untouched**.

Only `node-red.nix` changes. The dependency is guarded behind `features.homelab.home-assistant.enable`, and `TimeoutStartSec` is raised to 360s so systemd doesn't kill the start while the poll runs.

## Verification

- `nix eval` of the `server` config evaluates cleanly.
- Built the generated `podman-node-red.container`; confirmed `[Service] ExecStartPre=…/wait-for-home-assistant`, `TimeoutStartSec=360`, and `[Unit] After=podman-home-assistant.service`. ExecStartPre runs before the `podman run` ExecStart.
- Home-manager quadlet assertions pass (derivation builds).

## Caveat

`/` returning 200 means HA's HTTP server is up (≈ core started), which is *close to* but not identical to "every integration finished loading." A strict gate would poll `/api/config` for `state: RUNNING`, but that needs a long-lived token. This + Node-RED's own websocket reconnect covers the common case; can tighten later if gaps remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)