### PR TITLE
feat(firefox): add Frigate+ bookmark

### DIFF
--- a/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/self-hosted.nix
+++ b/system/home-manager/applications/firefox/profiles/s1n7ax/bookmarks/self-hosted.nix
@@ -17,6 +17,11 @@
             url = "http://192.168.1.110:8971";
           }
           {
+            name = "Frigate+";
+            tags = [ "self-hosted" ];
+            url = "https://plus.frigate.video/dashboard/";
+          }
+          {
             name = "Portainer";
             tags = [ "self-hosted" ];
             url = "http://192.168.1.110:9000/";


### PR DESCRIPTION
Adds a Frigate+ bookmark (https://plus.frigate.video/dashboard/) to the Self Hosted folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)