### PR TITLE
fix(xdg): pin ScreenCast portal to hyprland for Firefox

### DIFF
--- a/system/nixos/utils/xdg.nix
+++ b/system/nixos/utils/xdg.nix
@@ -16,5 +16,16 @@ with lib;
       xdg-desktop-portal-gtk
       kdePackages.xdg-desktop-portal-kde
     ];
+    # Pin ScreenCast/Screenshot to the hyprland backend; otherwise the request
+    # can resolve to the KDE backend, which Firefox can't use ("Needs permission
+    # to screen share"). gtk stays the default for file pickers etc.
+    config.common = {
+      default = [
+        "hyprland"
+        "gtk"
+      ];
+      "org.freedesktop.impl.portal.ScreenCast" = [ "hyprland" ];
+      "org.freedesktop.impl.portal.Screenshot" = [ "hyprland" ];
+    };
   };
 }


### PR DESCRIPTION
## Problem
Firefox showed **"Needs permission to screen share"** while Chromium worked fine.

## Cause
`MOZ_ENABLE_WAYLAND` is already set, so Firefox runs on Wayland. The issue is that three xdg-desktop-portal backends (hyprland, gtk, **kde**) are installed with no routing config, so the `ScreenCast` interface can resolve to the KDE backend — which Firefox can't drive outside a KWin session.

## Fix
Pin `org.freedesktop.impl.portal.ScreenCast` and `Screenshot` to the hyprland backend via `xdg.portal.config.common`; gtk remains the default for file pickers etc.

After rebuild, restart the portal (`systemctl --user restart xdg-desktop-portal`) or re-login, then relaunch Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)