### PR TITLE
feat(server): enable GitHub CLI on homelab

### DIFF
--- a/profile/server/options.nix
+++ b/profile/server/options.nix
@@ -35,6 +35,7 @@
 
     development = {
       git.enable = true;
+      github.enable = true;
       nix.enable = true;
       javascript.enable = true;
       ai = {


### PR DESCRIPTION
- Enable `features.development.github` on the server (homelab) profile, installing the `gh` CLI, matching the desktop profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)