### PR TITLE
feat(firefox): hide "Import Bookmarks…" toolbar button

### DIFF
--- a/system/home-manager/applications/firefox/profiles/s1n7ax/default.nix
+++ b/system/home-manager/applications/firefox/profiles/s1n7ax/default.nix
@@ -7,5 +7,9 @@
       default = "ddg";
       privateDefault = "ddg";
     };
+    settings = {
+      # Stop Firefox adding the "Import Bookmarks…" button to the toolbar
+      "browser.bookmarks.addedImportButton" = true;
+    };
   };
 }


### PR DESCRIPTION
Sets `browser.bookmarks.addedImportButton = true` on the personal Firefox profile so Firefox stops adding the "Import Bookmarks…" button to the bookmarks toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)