### PR TITLE
fix(frigate): enable lpr at global level

### DIFF
--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -207,6 +207,9 @@ with lib;
           enabled: true
           model_size: large
 
+        lpr:
+          enabled: true
+
         cameras:
           #--------------------------------------------------------------------#
           #                                ROAD                                #


### PR DESCRIPTION
## Summary
Camera `front_road` had `lpr` enabled but it was disabled at the global level, making the Frigate config invalid. Adds the global `lpr` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)