### PR TITLE
fix(frigate): drop COCO labelmap override on Frigate+ model

### DIFF
--- a/system/home-manager/homelab/frigate.nix
+++ b/system/home-manager/homelab/frigate.nix
@@ -141,19 +141,10 @@ with lib;
         #                               MODEL                                #
         #--------------------------------------------------------------------#
         model:
+          # Frigate+ model: only `path` should be set. The model ships its
+          # own labelmap (person, car, motorcycle, bicycle, dog, cat, ...),
+          # so no COCO-index remapping — that mislabeled e.g. dogs as cars.
           path: plus://062ae1e0ab694333027353df0d4eb982
-          # Relabel bicycle as motorcycle, and merge every other vehicle
-          # (motorcycle, airplane, bus, train, truck, boat) into car.
-          # COCO indices: 1=bicycle, 3=motorcycle, 4=airplane, 5=bus,
-          # 6=train, 7=truck, 8=boat.
-          labelmap:
-            1: motorcycle
-            3: car
-            4: car
-            5: car
-            6: car
-            7: car
-            8: car
 
         #--------------------------------------------------------------------#
         #                               DETECT                               #


### PR DESCRIPTION
## Summary
- Removed the hardcoded COCO-index `labelmap` from the Frigate+ `model` block.
- The Frigate+ model ships its own labelmap with its own index ordering (not COCO's), so the remap was pointing at the wrong classes — e.g. dogs were being detected as `car`.
- Per Frigate+ docs, only `path` should be set for plus models.

## Note
With the override gone, `bicycle` is now its own label (previously COCO-remapped to `motorcycle`); add it to `objects.track` if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)