### PR TITLE
feat(neovim): add useNightly flag to control nvim version

### DIFF
--- a/system/home-manager/applications/neovim.nix
+++ b/system/home-manager/applications/neovim.nix
@@ -1,8 +1,13 @@
 { pkgs, lib, config, inputs, ... }:
+let
+  neovimPkg = if config.features.editor.neovim.useNightly
+    then inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.default
+    else pkgs.neovim;
+in
 lib.mkIf config.features.editor.neovim.enable {
   programs.neovim = {
     enable = true;
-    package = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.default;
+    package = neovimPkg;
     # Keep our own ~/.config/nvim/init.lua (cloned from github.com/s1n7ax/nvim)
     # instead of letting HM write its provider config there and clobber it.
     sideloadInitLua = true;

--- a/system/options.nix
+++ b/system/options.nix
@@ -464,7 +464,14 @@ with lib;
     };
 
     editor = {
-      neovim.enable = mkEnableOption "Neovim editor";
+      neovim = {
+        enable = mkEnableOption "Neovim editor";
+        useNightly = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Use nightly Neovim build instead of stable.";
+        };
+      };
     };
 
     cli = {


### PR DESCRIPTION
## Summary
- Add a new `features.editor.neovim.useNightly` option to allow environments to opt into nightly Neovim builds
- Default to stable Neovim across all environments for consistency and stability
- Nightly can be enabled per-profile by setting the flag to true

## Test plan
- [x] Verify stable nvim is used by default
- [x] Verify nightly overlay is conditionally applied when useNightly is true

https://claude.ai/code/session_01CMMcTiRfVpq1zkYPhPVHfS